### PR TITLE
PRX-52: Target .NET 5.0 with PxCoco

### DIFF
--- a/Prexonite/Prexonite.csproj
+++ b/Prexonite/Prexonite.csproj
@@ -85,7 +85,7 @@
 
   <!-- These defitions are not used in a normal build. They can be useful for debugging PxCoco in the context of Prexonite. -->
   <!-- <PropertyGroup>
-    <PxCocoDebugTaskExt Condition=" '$(MSBuildRuntimeType)' == 'Core' ">netcoreapp2.2\PxCoco.dll</PxCocoDebugTaskExt>
+    <PxCocoDebugTaskExt Condition=" '$(MSBuildRuntimeType)' == 'Core' ">net5.0\PxCoco.dll</PxCocoDebugTaskExt>
     <PxCocoDebugTaskExt Condition=" '$(MSBuildRuntimeType)' != 'Core' ">net48\PxCoco.exe</PxCocoDebugTaskExt>
     <PxCocoTaskAssembly>$(MSBuildThisFileDirectory)..\PxCoco\bin\Debug\$(PxCocoDebugTaskExt)</PxCocoTaskAssembly>
   </PropertyGroup>
@@ -150,7 +150,7 @@
   <!-- NUGET References -->
   <ItemGroup>
     <PackageReference Include="Lokad.ILPack" Version="0.1.3" />
-    <PackageReference Include="PxCoco" Version="1.91.2" />
+    <PackageReference Include="PxCoco" Version="1.95.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="3.1.10" />
   </ItemGroup>

--- a/PxCoco/PxCoco.csproj
+++ b/PxCoco/PxCoco.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.2;net48</TargetFrameworks>
+    <TargetFrameworks>net5.0;net48</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <IsTool>true</IsTool>
-    <Version>1.91.1</Version>
+    <Version>1.95.0</Version>
     <Title>Prexonite Coco/R</Title>
     <PackageDescription>Coco/R is a compiler generator, which takes an attributed grammar of a source language and generates a scanner and a parser for this language. The scanner works as a deterministic finite automaton. The parser uses recursive descent. LL(1) conflicts can be resolved by a multi-symbol lookahead or by semantic checks. Thus the class of accepted grammars is LL(k) for an arbitrary k. The 'Prexonite' version is slightly modified and extended with MSBuild tasks.</PackageDescription>
     <Description>$(PackageDescription)</Description>

--- a/PxCoco/pxcoco-azure-ci-pipeline.yaml
+++ b/PxCoco/pxcoco-azure-ci-pipeline.yaml
@@ -23,7 +23,7 @@ variables:
 steps:
 - task: UseDotNet@2
   inputs:
-    version: '3.1.x'
+    version: '5.0.x'
 
 - task: DotNetCoreCLI@2
   displayName: Restore (Win)

--- a/PxCoco/pxcoco-azure-release-pipeline.yaml
+++ b/PxCoco/pxcoco-azure-release-pipeline.yaml
@@ -19,7 +19,7 @@ variables:
 steps:
 - task: UseDotNet@2
   inputs:
-    version: '3.1.x'
+    version: '5.0.x'
 
 - powershell: |
     # Remove /refs/tags (10 chars) and pxcoco/v. (9 chars) from checkout string


### PR DESCRIPTION
We don't want to mix .NET Core 2.2/3.1 with .NET 5.0.