### PR TITLE
PRX-8 Copy interpreter directive into output

### DIFF
--- a/Prexonite/Compiler/Loader.cs
+++ b/Prexonite/Compiler/Loader.cs
@@ -1114,20 +1114,20 @@ namespace Prexonite.Compiler
                     StoreCompressed(fstr);
             else
 #endif
-            using var writer = new StreamWriter(path, false);
+            using var writer = new StreamWriter(path, false) {NewLine = Options.StoreNewLine};
             Store(writer);
         }
 
         public string StoreInString()
         {
-            var writer = new StringWriter();
+            using var writer = new StringWriter {NewLine = Options.StoreNewLine};
             Store(writer);
             return writer.ToString();
         }
 
         public void Store(StringBuilder builder)
         {
-            using var writer = new StringWriter(builder);
+            using var writer = new StringWriter(builder) {NewLine = Options.StoreNewLine};
             Store(writer);
         }
 
@@ -1139,7 +1139,7 @@ namespace Prexonite.Compiler
                 throw new ArgumentNullException("str");
 
             using (GZipStream zip = new GZipStream(str, CompressionMode.Compress, true))
-            using (StreamWriter writer = new StreamWriter(zip, Encoding.UTF8))
+            using (StreamWriter writer = new StreamWriter(zip, Encoding.UTF8){NewLine = Options.StoreNewLine})
             {
                 writer.WriteLine("//PXSC");
                 Store(writer);
@@ -1152,6 +1152,14 @@ namespace Prexonite.Compiler
         {
             var app = ParentApplication;
 
+            // Interpreter line (if defined; nothing by default)
+            var interpreterLine = app.Meta[Application.InterpreterLineKey].Text;
+            if (!string.IsNullOrEmpty(interpreterLine))
+            {
+                writer.Write("#!");
+                writer.WriteLine(interpreterLine);
+            }
+            
             //Header
             writer.WriteLine("//PXS_");
             writer.WriteLine("//--GENERATED");

--- a/Prexonite/Compiler/LoaderOptions.cs
+++ b/Prexonite/Compiler/LoaderOptions.cs
@@ -140,6 +140,21 @@ namespace Prexonite.Compiler
             set => _flagLiteralsEnabled = value;
         }
 
+        [CanBeNull]
+        private string? _storeNewLine;
+
+        /// <summary>
+        /// The line separator to use when storing a compiled Prexonite program. 
+        /// </summary>
+        /// <see cref="Loader.Store(System.Text.StringBuilder)"/>
+        [PublicAPI]
+        [NotNull]
+        public string StoreNewLine
+        {
+            get => _storeNewLine ?? "\n";
+            set => _storeNewLine = value;
+        }
+
         #endregion
 
         public void InheritFrom([NotNull] LoaderOptions options)
@@ -155,6 +170,7 @@ namespace Prexonite.Compiler
             _storeSourceInformation ??= options._storeSourceInformation;
             _preflightModeEnabled ??= options._preflightModeEnabled;
             _flagLiteralsEnabled ??= options._flagLiteralsEnabled;
+            _storeNewLine ??= options._storeNewLine;
         }
     }
 }

--- a/PrexoniteTests/Tests/Compiler.Global.cs
+++ b/PrexoniteTests/Tests/Compiler.Global.cs
@@ -344,6 +344,29 @@ SomeOtherSettings ""Are Valid"";
             Assert.That(ldr.ParentApplication.Meta["SomeOtherSettings"], 
                 Is.EqualTo(new MetaEntry("Are Valid")));
         }
+        
+        [Test]
+        public void InterpreterLineIncludedInStoredRepresentation()
+        {
+            const string previousInterpreterLine = "/usr/bin/prx";
+            target.Meta[Application.InterpreterLineKey] = previousInterpreterLine;
+            var loader1 = _compile(@"
+SomeOtherSettings ""Are Valid"";
+");
+            var storedRepr = loader1.StoreInString();
+            Assert.That(storedRepr, Does.StartWith($"#!{previousInterpreterLine}\n"));
+            
+            var loader2 = new Loader(engine, new Application());
+            loader2.LoadFromString(storedRepr);
+            Assert.That(loader2.Errors, Is.Empty);
+            Assert.That(loader2.ParentApplication.Meta, Does.ContainKey(Application.InterpreterLineKey));
+            Assert.That(loader2.ParentApplication.Meta, Does.ContainKey("SomeOtherSettings"));
+            
+            Assert.That(loader2.ParentApplication.Meta[Application.InterpreterLineKey], 
+                Is.EqualTo(new MetaEntry(previousInterpreterLine)));
+            Assert.That(loader2.ParentApplication.Meta["SomeOtherSettings"], 
+                Is.EqualTo(new MetaEntry("Are Valid")));
+        }
 
         [Test]
         public void InterpreterLineAfterNoise()

--- a/prx.sln.DotSettings
+++ b/prx.sln.DotSettings
@@ -1,3 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fctx/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=predef/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=predef/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Repr/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
If an application has an interpreter directive, it will get copied into the final output.

This probably won't get used much, but it's easy to add.

Also:
 - Make newline used for output configurable
 - Change newline used for output to be just `\n` on all platforms. Part of my ongoing crusade to ban all use or `\r\n` :P But it's also crucial to make the interpreter directive work out of the box. `\r` gets interpreted as part of the command line on Linux.