### PR TITLE
PRX-47 ensure `name x:y/2.0;` is a compile error

### DIFF
--- a/PrexoniteTests/Tests/Translation.cs
+++ b/PrexoniteTests/Tests/Translation.cs
@@ -1388,6 +1388,24 @@ function main {
 ");
             Expect(SymbolInterpretations.Function);
         }
+
+        [Test]
+        public void ErrorSingleColonInMetaValue()
+        {
+            CompileInvalid(@"
+// There is a typo in this declaration: single `:` instead of `::`.
+name psr::pattern:test/2.0;
+");
+        }
+
+        [Test]
+        public void ErrorSingleColonInMetaValue2()
+        {
+            CompileInvalid(@"
+// There is a typo in this declaration: single `:` instead of `.` (this can happen on German keyboards)
+name psr.pattern:test/2.0;
+");
+        }
         
         [ContractAnnotation("value:null=>halt")]
         private static void _assumeNotNull(object value)


### PR DESCRIPTION
This PR adds two unit tests that try to replicate the issue, but the compiler _does already_ raise an error message.