### PR TITLE
PRX-32 add detection for ::-instead-of-. in namepsaces

### DIFF
--- a/Prexonite/Compiler/Grammar/Parser.GlobalScope.atg
+++ b/Prexonite/Compiler/Grammar/Parser.GlobalScope.atg
@@ -932,9 +932,20 @@ NsQualifiedIdImpl<false,out qualifiedId, out _>
 .
 
 NsTransferSource<out bool hasWildcard, out QualifiedId qualifiedId>
-                                    (.  hasWildcard = false; .)
+                                    (.  hasWildcard = false; 
+                                        var qualIdPos = GetPosition(); 
+                                        qualifiedId = new("unknown"); 
+                                    .)
 =
 NsQualifiedIdImpl<true, out qualifiedId, out hasWildcard>
+| GlobalQualifiedId<out var gid>    (.  // This alternative covers a common but hard to spot mistake (`.` vs `::`)
+                                        // It tries to recover, but it's considered a hard error.
+                                        Loader.ReportMessage(Message.Error(
+                                            Resources.Parser_DoubleColonInNamespaceName,
+                                            qualIdPos, MessageClasses.UnexpectedDoubleColonInNamespaceName));
+                                        hasWildcard = false;
+                                        qualifiedId = new(gid.Split('.'));
+                                    .)
 .
 
 NsQualifiedIdImpl<bool allowWildcard, out QualifiedId qualifiedId, out bool hasWildcard>
@@ -1091,7 +1102,7 @@ semicolon                           (.  if(!illegal)
                                     .)
 .
 
-NamespaceDeclaration                (.  QualifiedId fullNsId;
+NamespaceDeclaration                (.  QualifiedId? fullNsId = null;
                                         DeclarationScope scope = null;
                                         ISourcePosition qualIdPos,exportPos;
                                         List<SymbolTransferDirective> directives;
@@ -1100,7 +1111,16 @@ NamespaceDeclaration                (.  QualifiedId fullNsId;
                                     .)
 =                                   (.  .)
 namespace                           (.  qualIdPos = GetPosition(); .)
-NsQualifiedId<out fullNsId>         (.  var declBuilder = _prepareDeclScope(fullNsId, qualIdPos); .)
+(   NsQualifiedId<out var outNsId>  (.  fullNsId = outNsId; .) 
+|   GlobalQualifiedId<out var qid>  (.  // This alternative captures a common and hard to spot mistake (. vs ::)
+                                        // It tries to recover, but it's considered a hard error.
+                                        Loader.ReportMessage(Message.Error(
+                                            Resources.Parser_DoubleColonInNamespaceName,
+                                            qualIdPos, MessageClasses.UnexpectedDoubleColonInNamespaceName));
+                                        // Best-effort recovery based on invalid namespace name
+                                        fullNsId = new QualifiedId(qid.Split('.'));
+                                    .)
+)                                   (.  var declBuilder = _prepareDeclScope(fullNsId ?? new QualifiedId("unknown"), qualIdPos); .)
 [                                   (.  ISourcePosition importKeywordPosition;
                                         _pushLexerState(Lexer.Transfer);
                                     .)

--- a/Prexonite/Compiler/MessageClasses.cs
+++ b/Prexonite/Compiler/MessageClasses.cs
@@ -62,6 +62,7 @@ namespace Prexonite.Compiler
         public const string UnexpectedWildcard = "P.UnexpectedWildcard";
         public const string QualifiedIdPartsAfterWildcard = "P.QualifiedIdPartsAfterWildcard";
         public const string NonTopLevelNamespaceImport = "P.NonTopLevelNamespaceImport";
+        public const string UnexpectedDoubleColonInNamespaceName = "P.UnexpectedDoubleColonInNamespaceName";
 
         #endregion
 

--- a/Prexonite/Properties/Resources.resx
+++ b/Prexonite/Properties/Resources.resx
@@ -436,4 +436,7 @@
   <data name="MetaEntry_EntryTypeUnknownToString" xml:space="preserve">
     <value>MetaEntry type {0} does not have a string representation.</value>
   </data>
+  <data name="Parser_DoubleColonInNamespaceName" xml:space="preserve">
+    <value>Double colon (`::`) not allowed in namespace name.</value>
+  </data>
 </root>

--- a/PrexoniteTests/Tests/Translation.cs
+++ b/PrexoniteTests/Tests/Translation.cs
@@ -1406,7 +1406,72 @@ name psr::pattern:test/2.0;
 name psr.pattern:test/2.0;
 ");
         }
-        
+
+        [Test]
+        public void ErrorDoubleColonInNamespaceDecl()
+        {
+            var ldr = CompileInvalid(@"
+namespace a::b {
+  function should_be_illegal = null;
+}
+");
+            
+            Assert.That(ldr.Errors.Where(m => m.MessageClass == MessageClasses.UnexpectedDoubleColonInNamespaceName), Is.Not.Empty);
+            Assert.That(ldr.ErrorCount, Is.EqualTo(1), "Error count");
+        }
+
+        [Test]
+        public void ErrorDoubleColonInNamespaceImport()
+        {
+            var ldr = CompileInvalid(@"
+namespace a.b 
+{
+    function f = null;
+}
+namespace a.c 
+    import a::b::f 
+{
+    function should_be_illegal = null;
+}
+");
+            
+            Assert.That(ldr.Errors.Where(m => m.MessageClass == MessageClasses.UnexpectedDoubleColonInNamespaceName), Is.Not.Empty);
+            Assert.That(ldr.ErrorCount, Is.EqualTo(1), "Error count");
+        }
+
+        [Test]
+        public void ErrorDoubleColonInGlobalNamespaceImport()
+        {
+            var ldr = CompileInvalid(@"
+namespace a.b 
+{
+    function f = null;
+}
+namespace import a::b::f;
+function should_be_illegal = null;
+");
+            
+            Assert.That(ldr.Errors.Where(m => m.MessageClass == MessageClasses.UnexpectedDoubleColonInNamespaceName), Is.Not.Empty);
+            Assert.That(ldr.ErrorCount, Is.EqualTo(1), "Error count");
+        }
+
+        [Test]
+        public void ErrorDoubleColonInNamespaceExport()
+        {
+            var ldr = CompileInvalid(@"
+namespace b.c.d {
+    function f = null;
+}
+namespace a
+{
+    
+} export b::c;
+");
+            
+            Assert.That(ldr.Errors.Where(m => m.MessageClass == MessageClasses.UnexpectedDoubleColonInNamespaceName), Is.Not.Empty);
+            Assert.That(ldr.ErrorCount, Is.EqualTo(1), "Error count");
+        }
+
         [ContractAnnotation("value:null=>halt")]
         private static void _assumeNotNull(object value)
         {


### PR DESCRIPTION
It raises a hard error, but the parser tries its best to recover from the situation.