### PR TITLE
PRX-36: Error message for incomplete binary expr

### DIFF
--- a/Prexonite/Compiler/MessageClasses.cs
+++ b/Prexonite/Compiler/MessageClasses.cs
@@ -63,6 +63,7 @@ namespace Prexonite.Compiler
         public const string QualifiedIdPartsAfterWildcard = "P.QualifiedIdPartsAfterWildcard";
         public const string NonTopLevelNamespaceImport = "P.NonTopLevelNamespaceImport";
         public const string UnexpectedDoubleColonInNamespaceName = "P.UnexpectedDoubleColonInNamespaceName";
+        public const string IncompleteBinaryOperation = "P.IncompleteBinaryOperation";
 
         #endregion
 

--- a/Prexonite/Properties/Resources.resx
+++ b/Prexonite/Properties/Resources.resx
@@ -439,4 +439,10 @@
   <data name="Parser_DoubleColonInNamespaceName" xml:space="preserve">
     <value>Double colon (`::`) not allowed in namespace name.</value>
   </data>
+  <data name="Parser_BinaryOperandMissing_Left" xml:space="preserve">
+    <value>Left-hand side of {0} operation is missing.</value>
+  </data>
+  <data name="Parser_BinaryOperandMissing_Right" xml:space="preserve">
+    <value>Right-hand side of {0} operation is missing.</value>
+  </data>
 </root>

--- a/PrexoniteTests/Tests/Translation.cs
+++ b/PrexoniteTests/Tests/Translation.cs
@@ -1472,6 +1472,15 @@ namespace a
             Assert.That(ldr.ErrorCount, Is.EqualTo(1), "Error count");
         }
 
+        [Test]
+        public void QuestionMarkSpliceIsInvalid()
+        {
+            var ldr = CompileInvalid(@"
+function main = println(?*);
+");
+            Assert.That(ldr.Errors.Where(m => m.MessageClass == MessageClasses.IncompleteBinaryOperation), Is.Not.Empty);
+        }
+
         [ContractAnnotation("value:null=>halt")]
         private static void _assumeNotNull(object value)
         {


### PR DESCRIPTION
This PR introduces a more explicit error message for parsing errors where one of the operands of a binary expression end up missing.

This fixes an internal compiler error (`ArgumentNullException` when parsing `(?*)`)