### PR TITLE
PRX-55: Run tests in parallel

### DIFF
--- a/PrexoniteTests/Tests/ApplicationLinking.cs
+++ b/PrexoniteTests/Tests/ApplicationLinking.cs
@@ -34,6 +34,7 @@ using Prexonite.Modular;
 
 namespace PrexoniteTests.Tests
 {
+    [Parallelizable(ParallelScope.Fixtures | ParallelScope.Self)]
     [TestFixture]
     public class ApplicationLinking
     {

--- a/PrexoniteTests/Tests/AstTests.cs
+++ b/PrexoniteTests/Tests/AstTests.cs
@@ -32,6 +32,7 @@ using Prexonite.Compiler.Ast;
 
 namespace PrexoniteTests.Tests
 {
+    [Parallelizable(ParallelScope.Fixtures | ParallelScope.Self)]
     [TestFixture]
     public class AstTests
     {

--- a/PrexoniteTests/Tests/CilRuntime.cs
+++ b/PrexoniteTests/Tests/CilRuntime.cs
@@ -31,6 +31,7 @@ using Prexonite.Compiler.Cil;
 
 namespace PrexoniteTests.Tests
 {
+    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture]
     public class CilRuntime
     {

--- a/PrexoniteTests/Tests/Compiler.cs
+++ b/PrexoniteTests/Tests/Compiler.cs
@@ -33,6 +33,7 @@ using Prexonite.Compiler.Symbolic.Compatibility;
 
 namespace Prx.Tests
 {
+    [Parallelizable(ParallelScope.Fixtures)]
     public class Compiler
     {
         #region Setup

--- a/PrexoniteTests/Tests/Configurations/ScriptedUnitTestContainer.cs
+++ b/PrexoniteTests/Tests/Configurations/ScriptedUnitTestContainer.cs
@@ -38,6 +38,7 @@ using Prexonite.Types;
 
 namespace PrexoniteTests.Tests.Configurations
 {
+    [Parallelizable(ParallelScope.Fixtures)]
     internal abstract class ScriptedUnitTestContainer
     {
         public Application Application { get; set; }

--- a/PrexoniteTests/Tests/EmbeddedPrxLibTests.cs
+++ b/PrexoniteTests/Tests/EmbeddedPrxLibTests.cs
@@ -6,6 +6,7 @@ namespace PrexoniteTests.Tests
     /// <summary>
     /// These tests just verify that the prxlib/* embedded resources are present.
     /// </summary>
+    [Parallelizable(ParallelScope.Fixtures | ParallelScope.Self)]
     [TestFixture]
     public class EmbeddedPrxLibTests
     {

--- a/PrexoniteTests/Tests/LoaderTests.cs
+++ b/PrexoniteTests/Tests/LoaderTests.cs
@@ -8,6 +8,7 @@ using Prexonite.Compiler;
 
 namespace PrexoniteTests.Tests
 {
+    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture]
     public class LoaderTests
     {

--- a/PrexoniteTests/Tests/MExprTests.cs
+++ b/PrexoniteTests/Tests/MExprTests.cs
@@ -33,6 +33,7 @@ using Prexonite.Modular;
 
 namespace PrexoniteTests.Tests
 {
+    [Parallelizable(ParallelScope.Fixtures | ParallelScope.Self)]
     [TestFixture]
     public class MExprTests
     {

--- a/PrexoniteTests/Tests/MetaEntryTests.cs
+++ b/PrexoniteTests/Tests/MetaEntryTests.cs
@@ -4,6 +4,7 @@ using Prexonite;
 
 namespace PrexoniteTests.Tests
 {
+    [Parallelizable(ParallelScope.Fixtures | ParallelScope.Self)]
     [TestFixture]
     public class MetaEntryTests
     {

--- a/PrexoniteTests/Tests/Modular/ModuleNameTests.cs
+++ b/PrexoniteTests/Tests/Modular/ModuleNameTests.cs
@@ -4,6 +4,7 @@ using Prexonite.Modular;
 
 namespace PrexoniteTests.Tests.Modular
 {
+    [Parallelizable(ParallelScope.Fixtures | ParallelScope.Self)]
     [TestFixture]
     public class ModuleNameTests
     {

--- a/PrexoniteTests/Tests/NamespaceInfrastructureTests.cs
+++ b/PrexoniteTests/Tests/NamespaceInfrastructureTests.cs
@@ -37,6 +37,7 @@ using Prexonite.Modular;
 
 namespace PrexoniteTests.Tests
 {
+    [Parallelizable(ParallelScope.Fixtures | ParallelScope.Self)]
     [TestFixture]
     public class NamespaceInfrastructureTests
     {

--- a/PrexoniteTests/Tests/RandomAccessQueue.cs
+++ b/PrexoniteTests/Tests/RandomAccessQueue.cs
@@ -28,6 +28,7 @@ using Prexonite;
 
 namespace PrexoniteTests.Tests
 {
+    [Parallelizable(ParallelScope.Fixtures | ParallelScope.Self)]
     [TestFixture]
     public class RandomAccessQueue
     {

--- a/PrexoniteTests/Tests/Storage.cs
+++ b/PrexoniteTests/Tests/Storage.cs
@@ -32,6 +32,7 @@ using Prx.Tests;
 
 namespace PrexoniteTests.Tests
 {
+    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture]
     public class Storage : Compiler
     {

--- a/PrexoniteTests/Tests/TypeSystem.cs
+++ b/PrexoniteTests/Tests/TypeSystem.cs
@@ -32,6 +32,7 @@ using Prx.Tests;
 
 namespace PrexoniteTests.Tests
 {
+    [Parallelizable(ParallelScope.Fixtures | ParallelScope.Self)]
     [TestFixture(Description = "General type system checks")]
     public class TypeSystem
     {

--- a/PrexoniteTests/Tests/VMTestsBase.cs
+++ b/PrexoniteTests/Tests/VMTestsBase.cs
@@ -41,6 +41,7 @@ using Compiler = Prexonite.Compiler.Cil.Compiler;
 
 namespace PrexoniteTests.Tests
 {
+    [Parallelizable(ParallelScope.Fixtures)]
     public class VMTestsBase
     {
         public const string StoreDebugImplementationKey = "store_debug_implementation";


### PR DESCRIPTION
There are two kinds of test fixtures (classes)
 - fully parallel (no setup/teardown)
 - isolated from other tests (tests within the fixture cannot be parallelized but the fixture can run in parallel with others.)

The former gets the `[Parallelizable(ParallelScope.Fixtures | ParallelScope.Self)]` annotation; the latter only `[Parallelizable(ParallelScope.Fixtures)]`