### PR TITLE
PRX-29: add warning for unqualified import

### DIFF
--- a/Prexonite/Compiler/Grammar/Parser.GlobalScope.atg
+++ b/Prexonite/Compiler/Grammar/Parser.GlobalScope.atg
@@ -1025,6 +1025,7 @@ NsTransferSpec<SymbolStoreBuilder builder>
                                         ISourcePosition pos;
                                         ISymbolView<Symbol> sourceScope = null;
                                         var hasWildcard = false;
+                                        var sourcePosition = GetNextPosition();
                                     .)
 =
 NsTransferSource<out hasWildcard, out specRoot>              
@@ -1040,8 +1041,16 @@ NsTransferSource<out hasWildcard, out specRoot>
                                         }
                                         else
                                         {
-                                            var symId = specRoot[specRoot.Count-1];
+                                            var symId = specRoot[^1];
                                             specRoot = specRoot.WithSuffixDropped(1);
+                                            if (specRoot.Count == 0)
+                                            {
+                                                var msg = string.Format(Resources.Parser_NsTransferSpec_Import_has_no_effect_0, symId);
+                                                Loader.ReportMessage(Message.Warning(
+                                                    msg,
+                                                    sourcePosition,
+                                                    MessageClasses.UnqualifiedImport));
+                                            }
                                             sourceScope = _resolveNamespace(Symbols, pos, specRoot);
                                             directives.Add(SymbolTransferDirective.CreateRename(pos,symId,symId));
                                         }

--- a/Prexonite/Compiler/MessageClasses.cs
+++ b/Prexonite/Compiler/MessageClasses.cs
@@ -32,6 +32,7 @@ namespace Prexonite.Compiler
         public const string InvalidSymbolInterpretation = "ES.InvalidSymbolInterpretation";
         public const string SymbolConflict = "ES.SymbolConflict";
         public const string SymbolNotResolved = "ES.SymbolNotResolved";
+        public const string UnqualifiedImport = "ES.UnqualifiedImport";
 
         #region Parser
 

--- a/Prexonite/Properties/Resources.resx
+++ b/Prexonite/Properties/Resources.resx
@@ -466,4 +466,7 @@
   <data name="BuiltInTypeCommandBase_DoExpand_0_for_type_1_requires_an_arity_integer_as_the_first_argument" xml:space="preserve">
     <value>{0} for type {1} requires an arity (integer) as the first argument.</value>
   </data>
+  <data name="Parser_NsTransferSpec_Import_has_no_effect_0" xml:space="preserve">
+    <value>Import of symbol `{0}` has no effect. Did you mean `{0}(*)`?</value>
+  </data>
 </root>

--- a/PrexoniteTests/Tests/Translation.cs
+++ b/PrexoniteTests/Tests/Translation.cs
@@ -1440,6 +1440,28 @@ namespace a.c
         }
 
         [Test]
+        public void WarningUnqualifiedNamespace()
+        {
+            var ldr = new Loader(options);
+            Compile(ldr, @"
+namespace import unknown;
+");
+            Assert.That(ldr.Warnings.Where(m => m.MessageClass == MessageClasses.UnqualifiedImport), Is.Not.Empty);
+            Assert.That(ldr.Warnings.Count, Is.EqualTo(1), "Warning count");
+        }
+
+        [Test]
+        public void ErrorUnresolvedNamespace()
+        {
+            var ldr = CompileInvalid(@"
+namespace a {}
+namespace import a.b.c;
+");
+            Assert.That(ldr.Errors.Where(m => m.MessageClass == MessageClasses.NamespaceExcepted), Is.Not.Empty);
+            Assert.That(ldr.ErrorCount, Is.EqualTo(1));
+        }
+
+        [Test]
         public void ErrorDoubleColonInGlobalNamespaceImport()
         {
             var ldr = CompileInvalid(@"

--- a/Tools/Parser.frame
+++ b/Tools/Parser.frame
@@ -66,11 +66,23 @@ internal partial class Parser {
 		errors.parentParser = this;
 	}
 
-  
-  public Prexonite.Compiler.ISourcePosition GetPosition()
-  {
-      return new Prexonite.Compiler.SourcePosition(scanner.File, t.line, t.col);
-  }
+  	/// <summary>
+  	/// Constructs the position of the last token.
+  	/// </summary>
+  	/// <returns>The position of the last token.</returns>
+    public Prexonite.Compiler.ISourcePosition GetPosition()
+    {
+        return new Prexonite.Compiler.SourcePosition(scanner.File, t.line, t.col);
+    }
+
+    /// <summary>
+    /// Constructs the position of the next (look-ahead) token.
+    /// </summary>
+    /// <returns>The position of the next (look-ahead) token.</returns>
+    public Prexonite.Compiler.ISourcePosition GetNextPosition()
+    {
+        return new Prexonite.Compiler.SourcePosition(scanner.File, la.line, la.col);
+    }
 
     [DebuggerNonUserCode]
 	void SynErr (int n) {


### PR DESCRIPTION
`namespace import x;` doesn't do anything. Either `x` is already in scope (in which case, this is a no-op) or `x` is not in scope (which results in an error symbol being declared).

For now, I've decided not to immediately emit an error for unresolved symbols. Not 100% sure if I'm going to keep imports this way.

The rationale is that Prexonite Script doesn't have robust IDE support and thus micro-managing imports is painful. Having a compilation fail because of an unused but unresolved import sounds annoying to me.

Also:
 - Introduce `GetNextPosition` method. See PRX-57
 
Fixes PRX-29