### PR TITLE
PRX-48: single-file prx binary

### DIFF
--- a/.github/workflows/PrxCi.yml
+++ b/.github/workflows/PrxCi.yml
@@ -26,7 +26,7 @@ jobs:
           - linux
         include: 
           - os: windows
-            build_platform: windows-2019
+            build_platform: windows-2022
           - os: linux
             build_platform: ubuntu-20.04
     name: Build & Test Prexonite on ${{ matrix.os }}

--- a/.github/workflows/PrxRelease.yml
+++ b/.github/workflows/PrxRelease.yml
@@ -7,8 +7,22 @@ on:
 
 jobs:
   build:
-    name: Release Prexonite
-    runs-on: windows-2019
+    strategy:
+      matrix:
+        os:
+          - windows
+          - linux
+        include:
+          - os: windows
+            build_platform: windows-2022
+            runtime_ident: win-64
+          - os: linux
+            build_platform: ubuntu-20.04
+            runtime_ident: linux-x64
+    name: Release Prexonite on ${{ matrix.os }}
+    runs-on: ${{ matrix.build_platform }}
+    permissions:
+      contents: write # required for creating a release
 
     steps:
       - name: Determine version
@@ -53,41 +67,42 @@ jobs:
         run: dotnet build --configuration=Release --no-restore --verbosity=normal -p:Version=${{steps.determine-version.outputs.version}}
       - name: Test
         run: dotnet test --configuration=Release --no-restore --no-build --verbosity=normal -p:Version=${{steps.determine-version.outputs.version}}
-      - name: Pack
+      - name: Pack (windows-only)
+        if: matrix.os == 'windows'
         run: dotnet pack --configuration=Release --no-restore --no-build --verbosity=normal -p:Version=${{steps.determine-version.outputs.version}}
       - name: Publish
         run: dotnet publish --configuration=Release --no-restore --no-build --verbosity=normal -p:Version=${{steps.determine-version.outputs.version}}
-#      - name: Prepare Binary ZIP
-#        run: |
-#          ver='${{steps.determine-version.outputs.version}}'
-#          cd Prx/bin/Release/net5.0/ && \
-#            mkdir zip-env && \
-#            mv publish "zip-env/prexonite-v$ver"
-#        shell: bash
-#      - name: Binary ZIP
-#        uses: thedoctor0/zip-release@0.4.1
-#        with:
-#          filename: prexonite-v${{steps.determine-version.outputs.version}}
-#          directory: Prx/bin/Release/net5.0/zip-env
-      - name: Push Prexonite Package
-        run: dotnet nuget push Prexonite/bin/Release/Prexonite.${{steps.determine-version.outputs.version}}.nupkg
-      - name: Push Prexonite Symbols Package
-        run: dotnet nuget push Prexonite/bin/Release/Prexonite.${{steps.determine-version.outputs.version}}.snupkg
-      - name: Push Prx Package
-        run: dotnet nuget push Prx/bin/Release/Prx.${{steps.determine-version.outputs.version}}.nupkg
-      - name: Push Prx Symbols Package
-        run: dotnet nuget push Prx/bin/Release/Prx.${{steps.determine-version.outputs.version}}.snupkg
-      - name: Create Release 
-        uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Prepare Binary ZIP
+        run: |
+          ver='${{steps.determine-version.outputs.version}}'
+          cd Prx/bin/Release/net6.0/${{ matrix.runtime_ident }} && \
+            mkdir zip-env && \
+            mv publish "zip-env/prexonite-v$ver"
+        shell: bash
+      - name: Binary ZIP
+        uses: thedoctor0/zip-release@0.6.1
         with:
+          filename: prexonite-v${{steps.determine-version.outputs.version}}-${{ matrix.runtime_ident }}.zip
+          directory: Prx/bin/Release/net6.0/${{ matrix.runtime_ident }}/zip-env
+      - name: Push Prexonite Package (windows-only)
+        if: matrix.os == 'windows'
+        run: dotnet nuget push Prexonite/bin/Release/Prexonite.${{steps.determine-version.outputs.version}}.nupkg
+      - name: Push Prexonite Symbols Package (windows-only)
+        if: matrix.os == 'windows'
+        run: dotnet nuget push Prexonite/bin/Release/Prexonite.${{steps.determine-version.outputs.version}}.snupkg
+      - name: Push Prx Package (windows-only)
+        if: matrix.os == 'windows'
+        run: dotnet nuget push Prx/bin/Release/Prx.${{steps.determine-version.outputs.version}}.nupkg
+      - name: Push Prx Symbols Package (windows-only)
+        if: matrix.os == 'windows'
+        run: dotnet nuget push Prx/bin/Release/Prx.${{steps.determine-version.outputs.version}}.snupkg
+      - name: Create Release
+        uses: ncipollo/release-action@v1.10.0
+        with:
+          allowUpdates: true
+          artifacts: '**/Prexonite*.nupkg,**/Prexonite*.snupkg,**/Prx*.nupkg,**/Prx*.snupkg,prexonite-v*.zip'
+          artifactErrorsFailBuild: true
           draft: true
-          name:  ${{steps.determine-version.outputs.version}}
-          fail_on_unmatched_files: true
-          files: |
-            **/Prexonite*.nupkg
-            **/Prexonite*.snupkg
-            **/Prx*.nupkg
-            **/Prx*.snupkg
-
+          generateReleaseNotes: true
+          omitBodyDuringUpdate: true
+          omitDraftDuringUpdate: true

--- a/.github/workflows/PxCocoCi.yml
+++ b/.github/workflows/PxCocoCi.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build:
     name: Build PxCoco (CI)
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/PxCocoRelease.yml
+++ b/.github/workflows/PxCocoRelease.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   release:
     name: Build and Release PxCoco
-    runs-on: windows-2019
+    runs-on: windows-2022
     permissions:
       packages: write
       contents: read

--- a/Prexonite/Commands/Core/LoadAssembly.cs
+++ b/Prexonite/Commands/Core/LoadAssembly.cs
@@ -74,7 +74,21 @@ public sealed class LoadAssembly : PCommand, ICilCompilerAware
                 throw new FileNotFoundException("Prexonite can't load assembly located in " +
                     path);
 
-            eng.RegisterAssembly(Assembly.LoadFile(asmFile.FullName));
+            Assembly assembly;
+            if (asmFile is FileSpec { FullName: var asmFilePath })
+            {
+                // Use file path based loading to give the CLR file system context.
+                assembly = Assembly.LoadFrom(asmFilePath);
+            }
+            else
+            {
+                using var stream = asmFile.OpenStream();
+                using var buf = new MemoryStream();
+                stream.CopyTo(buf);
+                assembly = Assembly.Load(buf.GetBuffer());
+            }
+
+            eng.RegisterAssembly(assembly);
         }
 
         return PType.Null.CreatePValue();

--- a/Prexonite/Compiler/Build/ITarget.cs
+++ b/Prexonite/Compiler/Build/ITarget.cs
@@ -63,6 +63,7 @@ public interface ITarget
     IReadOnlyCollection<Message> Messages { get; }
 
     [PublicAPI]
+    [CanBeNull]
     Exception Exception { get; }
 
     bool IsSuccessful { get; }

--- a/Prexonite/Compiler/Build/Internal/SelfAssemblingPlan.cs
+++ b/Prexonite/Compiler/Build/Internal/SelfAssemblingPlan.cs
@@ -166,7 +166,7 @@ public class SelfAssemblingPlan : IncrementalPlan, ISelfAssemblingPlan
             {
                 refSpec.Source = new FileSource(refSpec.ResolvedPath, Encoding);
                 await Task.Yield(); // Need to yield at this point to keep
-                // the critical section of the cache short
+                // the critical section of the cache update short
                 return await _performPreflight(refSpec, actualToken);
             }, token);
     }
@@ -256,7 +256,7 @@ public class SelfAssemblingPlan : IncrementalPlan, ISelfAssemblingPlan
     }
 
     [NotNull]
-    private static readonly Regex _fileReferencePattern = new(@"^(\.|/|:)");
+    private static readonly Regex _fileReferencePattern = new(@"^([/.]|[a-zA-Z]:)");
 
     private static RefSpec _parseRefSpec(MetaEntry entry)
     {

--- a/Prexonite/Compiler/Build/Plan.cs
+++ b/Prexonite/Compiler/Build/Plan.cs
@@ -41,11 +41,11 @@ public static class Plan
     /// <summary>List of modules included in the Prexonite assembly. Does not include 'sys' itself.</summary>
     private static readonly ISource[] _stdLibModules =
     {
-        Source.FromEmbeddedResource("prxlib.prx.prim.pxs"),
-        Source.FromEmbeddedResource("prxlib.prx.core.pxs"),
-        Source.FromEmbeddedResource("prxlib.sys.pxs"),
-        Source.FromEmbeddedResource("prxlib.prx.v1.pxs"),
-        Source.FromEmbeddedResource("prxlib.prx.v1.prelude.pxs")
+        Source.FromEmbeddedPrexoniteResource("prxlib.prx.prim.pxs"),
+        Source.FromEmbeddedPrexoniteResource("prxlib.prx.core.pxs"),
+        Source.FromEmbeddedPrexoniteResource("prxlib.sys.pxs"),
+        Source.FromEmbeddedPrexoniteResource("prxlib.prx.v1.pxs"),
+        Source.FromEmbeddedPrexoniteResource("prxlib.prx.v1.prelude.pxs")
     };
 
     public static IPlan CreateDefault()

--- a/Prexonite/Compiler/Build/Source.cs
+++ b/Prexonite/Compiler/Build/Source.cs
@@ -76,10 +76,16 @@ public static class Source
         return FromStream(new MemoryStream(data, false), encoding, false);
     }
 
-    public static ISource FromEmbeddedResource([NotNull] string name)
+    public static ISource FromEmbeddedPrexoniteResource([NotNull] string name)
     {
         if (name == null) throw new ArgumentNullException(nameof(name));
         return new EmbeddedResourceSource(Assembly.GetExecutingAssembly(), "Prexonite." + name);
+    }
+    
+    public static ISource FromEmbeddedResource([NotNull] Assembly assembly, [NotNull] string name)
+    {
+        if (name == null) throw new ArgumentNullException(nameof(name));
+        return new EmbeddedResourceSource(assembly, name);
     }
 
     [NotNull]

--- a/Prexonite/Compiler/ISourceSpec.cs
+++ b/Prexonite/Compiler/ISourceSpec.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using System;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using Prexonite.Compiler.Build;
+
+namespace Prexonite.Compiler;
+
+/// <summary>
+/// A retro-fitted precursor to <see cref="ISource"/> (<see cref="Source"/>). It is used to support including
+/// Prexonite Script files embedded as resources. Modern code should prefer using modules and the build system
+/// (with one module per embedded resource). 
+/// </summary>
+/// <seealso cref="Plan"/>
+public interface ISourceSpec
+{
+    public string FullName { get; }
+    public string ShortName { get; }
+    public Stream OpenStream();
+    public string? LoadPath { get; }
+
+    public ISource ToSource();
+
+    public bool Exists();
+}
+
+public sealed record FileSpec(FileInfo File) : ISourceSpec
+{
+    public FileSpec(string path) : this(new FileInfo(path)) { }
+    
+    public string FullName => File.FullName;
+    public string ShortName => File.Name;
+    public string? LoadPath => File.DirectoryName;
+
+    public Stream OpenStream() => new FileStream(
+        File.FullName,
+        FileMode.Open,
+        FileAccess.Read,
+        FileShare.Read,
+        4 * 1024,
+        FileOptions.SequentialScan);
+
+    public ISource ToSource() => Source.FromFile(File, Encoding.UTF8);
+    public bool Exists() => System.IO.File.Exists(FullName);
+}
+    
+public sealed record ResourceSpec(Assembly ResourceAssembly, string Name) : ISourceSpec
+{
+    public const string Prefix = "resource:";
+    public string FullName => $"{Prefix}{ResourceAssembly.FullName ?? "<unknown assembly>"}:{Name}";
+    string ISourceSpec.ShortName => Name;
+
+    public Stream OpenStream() => ResourceAssembly.GetManifestResourceStream(Name) 
+        ?? throw new InvalidOperationException($"Assembly {ResourceAssembly.FullName} does not " +
+            $"contain a resource '{Name}' (or it is not accessible).");
+
+    public string? LoadPath => null;
+
+    public ISource ToSource() => Source.FromEmbeddedResource(ResourceAssembly, Name);
+
+    public bool Exists() => ResourceAssembly.GetManifestResourceInfo(Name) != null;
+}

--- a/Prexonite/Compiler/Internal/AssemblyResolver.cs
+++ b/Prexonite/Compiler/Internal/AssemblyResolver.cs
@@ -1,0 +1,102 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+
+namespace Prexonite.Compiler.Internal;
+
+internal sealed class AssemblyResolver : ICloneable
+{
+    private readonly ConcurrentDictionary<AssemblyName, Assembly> _assemblies = new();
+    private readonly ConcurrentDictionary<string, Assembly> _cache = new();
+
+    public Assembly Resolve(string name) => TryResolve(name) ??
+        throw new PrexoniteException($"Could not resolve assembly by name '{name}'. Is it loaded?");
+
+    public Assembly? TryResolve(string name)
+    {
+        // as an optimization, check if there is a cache hit
+        if (_cache.TryGetValue(name, out var cacheHit))
+        {
+            return cacheHit;
+        }
+
+        // try to resolve the assembly (note that we can't use GetOrAdd because the resolution might fail)
+        Assembly? resolvedAssembly = null;
+        foreach (var assembly in _assemblies.Values)
+        {
+            if (Engine.DefaultStringComparer.Equals(assembly.FullName, name)
+                || assembly.GetName() is var otherName &&
+                (Engine.DefaultStringComparer.Equals(otherName.Name, name)
+                    || Engine.DefaultStringComparer.Equals($"{otherName.Name},{otherName.Version}", name)))
+            {
+                resolvedAssembly = assembly;
+                break;
+            }
+        }
+
+        return resolvedAssembly == null ? resolvedAssembly : _cache.GetOrAdd(name, resolvedAssembly);
+    }
+
+    /// <summary>
+    ///     Determines whether an assembly is already registered for use by the Prexonite VM.
+    /// </summary>
+    /// <param name = "ass">An assembly reference.</param>
+    /// <returns>True if the supplied assembly is registered; false otherwise.</returns>
+    [DebuggerStepThrough]
+    public bool Contains(Assembly? ass) => ass != null && _assemblies.ContainsKey(ass.GetName());
+
+    /// <summary>
+    ///     Gets a list of all registered assemblies.
+    /// </summary>
+    /// <returns>A copy of the list of registered assemblies.</returns>
+    [DebuggerStepThrough]
+    public Assembly[] ToArray() => _assemblies.Values.ToArray();
+
+    /// <summary>
+    ///     Registers a new assembly for use by the Prexonite VM.
+    /// </summary>
+    /// <param name = "ass">An assembly reference.</param>
+    /// <exception cref = "ArgumentNullException"><paramref name = "ass" /> is null.</exception>
+    [DebuggerStepThrough]
+    public void Add(Assembly ass)
+    {
+        if (ass == null)
+            throw new ArgumentNullException(nameof(ass));
+        _assemblies.GetOrAdd(ass.GetName(), ass);
+    }
+
+    /// <summary>
+    ///     Removes an assembly from the list registered ones.
+    /// </summary>
+    /// <param name = "ass">The assembly to remove.</param>
+    /// <exception cref = "ArgumentNullException"><paramref name = "ass" /> is null.</exception>
+    [DebuggerStepThrough]
+    public void Remove(Assembly ass)
+    {
+        if (ass == null)
+            throw new ArgumentNullException(nameof(ass));
+        _assemblies.TryRemove(ass.GetName(), out _);
+        foreach (var (shortName, cached) in _cache)
+        {
+            if (ass == cached)
+            {
+                _cache.TryRemove(shortName, out _);
+            }
+        }
+    }
+
+    public AssemblyResolver Clone()
+    {
+        var copy = new AssemblyResolver();
+        copy._assemblies.AddRange(_assemblies);
+        // NOTE: we intentionally don't copy the cache. The cache is an optimization that should remain tied to
+        // a single engine. The clone should not copy over cache entries (which might never be relevant to the
+        // clone).
+        return copy;
+    }
+    
+    object ICloneable.Clone() => Clone();
+}

--- a/Prexonite/Compiler/Internal/PathSet.cs
+++ b/Prexonite/Compiler/Internal/PathSet.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Prexonite.Compiler.Internal;
+
+/// <summary>
+/// A set of file system paths. Tries to normalize paths (on a best-effort basis).
+/// </summary>
+/// <remarks>
+/// This class is aware of <see cref="ResourceSpec"/>.</remarks>
+internal sealed class PathSet : ICollection<string>
+{
+    private readonly HashSet<string> _paths = new();
+    public IEnumerator<string> GetEnumerator()
+    {
+        return _paths.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return ((IEnumerable)_paths).GetEnumerator();
+    }
+
+    public void Add(string path) => _paths.Add(canonical(path));
+
+    public void Clear()
+    {
+        _paths.Clear();
+    }
+
+    public bool Contains(string path) => _paths.Contains(canonical(path));
+
+    public void CopyTo(string[] array, int arrayIndex)
+    {
+        _paths.CopyTo(array, arrayIndex);
+    }
+
+    public bool Remove(string path) => _paths.Remove(canonical(path));
+
+    public int Count => _paths.Count;
+
+    bool ICollection<string>.IsReadOnly => ((ICollection<string>)_paths).IsReadOnly;
+
+    private static string canonical(string path)
+    {
+        if (!path.StartsWith(ResourceSpec.Prefix))
+        {
+            path = Path.GetFullPath(path);
+            if (OperatingSystem.IsMacOS() || OperatingSystem.IsWindows())
+            {
+                // PRX-58 This generalization is of course not correct, but there currently is no convenient API
+                // to get a canonical path.
+                path = path.ToUpperInvariant();
+            }
+        }
+
+        return path;
+    }
+}

--- a/PrexoniteTests/Tests/Configurations/ModuleCache.cs
+++ b/PrexoniteTests/Tests/Configurations/ModuleCache.cs
@@ -72,7 +72,7 @@ public static class ModuleCache
     {
         var moduleName = new ModuleName("prx.v1", new Version(0, 0));
         var desc = Cache.CreateDescription(moduleName,
-            Source.FromEmbeddedResource("prxlib.prx.v1.prelude.pxs"),
+            Source.FromEmbeddedPrexoniteResource("prxlib.prx.v1.prelude.pxs"),
             "prxlib/prx.v1.prelude.pxs",
             Enumerable.Empty<ModuleName>());
         Cache.TargetDescriptions.Add(desc);
@@ -89,29 +89,29 @@ public static class ModuleCache
         _legacySymbolsDescription ??= _loadLegacySymbols();
     // ReSharper restore InconsistentNaming
 
-    private static ITargetDescription StdlibDescription => _stdlibDescription ??= _loadStdlib();
+    private static ITargetDescription stdlibDescription => _stdlibDescription ??= _loadStdlib();
 
     private static ITargetDescription _loadStdlib()
     {
         try
         {
             var v1Name = new ModuleName("prx", new Version(1, 0));
-            var v1Desc = Cache.CreateDescription(v1Name, Source.FromEmbeddedResource("prxlib.prx.v1.pxs"),
+            var v1Desc = Cache.CreateDescription(v1Name, Source.FromEmbeddedPrexoniteResource("prxlib.prx.v1.pxs"),
                 "prxlib/prx.v1.pxs", Enumerable.Empty<ModuleName>());
             Cache.TargetDescriptions.Add(v1Desc);
                 
             var primName = new ModuleName("prx.prim", new Version(0, 0));
-            var primDesc = Cache.CreateDescription(primName, Source.FromEmbeddedResource("prxlib.prx.prim.pxs"),
+            var primDesc = Cache.CreateDescription(primName, Source.FromEmbeddedPrexoniteResource("prxlib.prx.prim.pxs"),
                 "prxlib/prx.prim.pxs", Enumerable.Empty<ModuleName>());
             Cache.TargetDescriptions.Add(primDesc);
 
             var coreName = new ModuleName("prx.core", new Version(0, 0));
-            var coreDesc = Cache.CreateDescription(coreName, Source.FromEmbeddedResource("prxlib.prx.core.pxs"),
+            var coreDesc = Cache.CreateDescription(coreName, Source.FromEmbeddedPrexoniteResource("prxlib.prx.core.pxs"),
                 "prxlib/prx.core.pxs", primName.Singleton());
             Cache.TargetDescriptions.Add(coreDesc);
 
             var sysName = new ModuleName("sys", new Version(0, 0));
-            var desc = Cache.CreateDescription(sysName, Source.FromEmbeddedResource("prxlib.sys.pxs"), "prxlib/sys.pxs",
+            var desc = Cache.CreateDescription(sysName, Source.FromEmbeddedPrexoniteResource("prxlib.sys.pxs"), "prxlib/sys.pxs",
                 new[]{ primName, coreName });
             Cache.TargetDescriptions.Add(desc);
 
@@ -149,7 +149,7 @@ public static class ModuleCache
         var dependencies = script.Dependencies ?? Enumerable.Empty<string>();
 
         var file = environment.ApplyLoadPaths(path);
-        if (file == null || !file.Exists)
+        if (file == null)
             throw new PrexoniteException($"Cannot find script {path}.");
 
         var moduleName = new ModuleName(Path.GetFileNameWithoutExtension(path), new Version(0, 0));
@@ -167,8 +167,8 @@ public static class ModuleCache
                 new ModuleName(Path.GetFileNameWithoutExtension(dep), new Version(0, 0))).ToArray();
 
         // Manually add legacy symbol and stdlib dependencies
-        var effectiveDependencies = dependencyNames.Append(LegacySymbolsDescription.Name).Append(StdlibDescription.Name);
-        var desc = Cache.CreateDescription(moduleName, Source.FromFile(file,Encoding.UTF8), path, effectiveDependencies);
+        var effectiveDependencies = dependencyNames.Append(LegacySymbolsDescription.Name).Append(stdlibDescription.Name);
+        var desc = Cache.CreateDescription(moduleName, file.ToSource(), path, effectiveDependencies);
         _trace.TraceEvent(TraceEventType.Information, 0,
             "Adding new target description for cache on thread {0}: {1}.", Thread.CurrentThread.ManagedThreadId,
             desc);

--- a/PrexoniteTests/Tests/EmbeddedPrxLibTests.cs
+++ b/PrexoniteTests/Tests/EmbeddedPrxLibTests.cs
@@ -42,7 +42,7 @@ public class EmbeddedPrxLibTests
 
     private static void _checkEmbeddedResource(string name)
     {
-        Assert.True(Source.FromEmbeddedResource(name).TryOpen(out var reader), $"Cannot open {name}");
+        Assert.True(Source.FromEmbeddedPrexoniteResource(name).TryOpen(out var reader), $"Cannot open {name}");
         var contents = reader.ReadToEnd();
         Assert.That(contents, Is.Not.Null);
         Assert.That(contents.Length, Is.GreaterThan(100));

--- a/PrexoniteTests/Tests/LoaderTests.cs
+++ b/PrexoniteTests/Tests/LoaderTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using NUnit.Framework;
 using Prexonite;
 using Prexonite.Compiler;
@@ -102,6 +103,45 @@ public class LoaderTests
     public void Sub2ForwardSlashRelative()
     {
         _assertFindsFile("./sub1/sub2/sub2.pxs", "sub1", "sub2", "sub2.pxs");
+    }
+    
+
+    [Test]
+    public void EmbeddedResourceByName()
+    {
+        var spec = _ldr.ApplyLoadPaths("resource:Prexonite:Prexonite.prxlib.sys.pxs");
+
+        Assert.That(spec, Is.Not.Null);
+        Assert.That(spec, Is.InstanceOf<ResourceSpec>());
+        Assert.That(((ResourceSpec) spec).Name, Is.EqualTo("Prexonite.prxlib.sys.pxs"));
+        Assert.That(((ResourceSpec) spec).ResourceAssembly, Is.SameAs(Assembly.GetAssembly(typeof(Engine))));
+    }
+
+    [Test]
+    public void EmbeddedResourceByFullName()
+    {
+        var spec = _ldr.ApplyLoadPaths($"resource:{Assembly.GetAssembly(typeof(Engine))!.FullName}:Prexonite.prxlib.sys.pxs");
+
+        Assert.That(spec, Is.Not.Null);
+        Assert.That(spec, Is.InstanceOf<ResourceSpec>());
+        Assert.That(((ResourceSpec) spec).Name, Is.EqualTo("Prexonite.prxlib.sys.pxs"));
+        Assert.That(((ResourceSpec) spec).ResourceAssembly, Is.SameAs(Assembly.GetAssembly(typeof(Engine))));
+    }
+
+    [Test]
+    public void EmbeddedResourceAssemblyNotFound()
+    {
+        var spec = _ldr.ApplyLoadPaths($"resource:DoesNotExist:Prexonite.prxlib.sys.pxs");
+
+        Assert.That(spec, Is.Null);
+    }
+
+    [Test]
+    public void EmbeddedResourceNotFound()
+    {
+        var spec = _ldr.ApplyLoadPaths($"resource:Prexonite:doesnotexist.pxs");
+
+        Assert.That(spec, Is.Null);
     }
 
     private void _assertFindsFile(string logicalPath, params string[] physicalPathComponents)

--- a/Prx/Prx.csproj
+++ b/Prx/Prx.csproj
@@ -23,15 +23,34 @@
     <Product>Prexonite</Product>
     <Company>$(Product)</Company>
     <NeutralLanguage>en-US</NeutralLanguage>
+    
+    <!-- single file app -->
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <RuntimeIdentifier Condition="$([MSBuild]::IsOSPlatform('Windows'))">win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux-x64</RuntimeIdentifier>
+    <!-- Teady to run makes a HUGE difference in terms of startup time. 
+         Reduces startup time from ~820ms down to ~210ms.  -->
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <!-- While compression can reduce the file size by about 50%, it also almost doubles the overhead for launching the
+         interpreter (210ms -> 350-450ms) to the point where the delay becomes much more noticable.
+     -->
+    <EnableCompressionInSingleFile>false</EnableCompressionInSingleFile>
+    <!-- Can't use assembly trimming because the Prx interpreter heavily relies on reflection.
+         Interestingly, there is sufficient overlap to run  the basic prx application.
+         That means: if you are only interested in the compiler and a basic REPL, you can use a 19MB trimmed 
+         application.
+     -->
+    <PublishTrimmed>false</PublishTrimmed>
   </PropertyGroup>
 
   <ItemGroup>
     <None Remove="src\prx_interactive.pxs" />
     <None Remove="src\prx_lib.pxs" />
     <None Remove="src\prx_main.pxs" />
-    <EmbeddedResource Include="src\prx_interactive.pxs" />
-    <EmbeddedResource Include="src\prx_lib.pxs" />
-    <EmbeddedResource Include="src\prx_main.pxs" />
+    <EmbeddedResource Include="src\prx_interactive.pxs" LogicalName="prx_interactive.pxs" />
+    <EmbeddedResource Include="src\prx_lib.pxs" LogicalName="prx_lib.pxs" />
+    <EmbeddedResource Include="src\prx_main.pxs" LogicalName="prx_main.pxs" />
     <None Update="psr\_2\psr\prop.pxs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Prx/Prx.csproj
+++ b/Prx/Prx.csproj
@@ -23,26 +23,32 @@
     <Product>Prexonite</Product>
     <Company>$(Product)</Company>
     <NeutralLanguage>en-US</NeutralLanguage>
-    
-    <!-- single file app -->
-    <PublishSingleFile>true</PublishSingleFile>
-    <SelfContained>true</SelfContained>
-    <RuntimeIdentifier Condition="$([MSBuild]::IsOSPlatform('Windows'))">win-x64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux-x64</RuntimeIdentifier>
-    <!-- Teady to run makes a HUGE difference in terms of startup time. 
-         Reduces startup time from ~820ms down to ~210ms.  -->
-    <PublishReadyToRun>true</PublishReadyToRun>
-    <!-- While compression can reduce the file size by about 50%, it also almost doubles the overhead for launching the
-         interpreter (210ms -> 350-450ms) to the point where the delay becomes much more noticable.
-     -->
-    <EnableCompressionInSingleFile>false</EnableCompressionInSingleFile>
-    <!-- Can't use assembly trimming because the Prx interpreter heavily relies on reflection.
-         Interestingly, there is sufficient overlap to run  the basic prx application.
-         That means: if you are only interested in the compiler and a basic REPL, you can use a 19MB trimmed 
-         application.
-     -->
-    <PublishTrimmed>false</PublishTrimmed>
   </PropertyGroup>
+
+  <!-- single file app (Release-Mode only) -->
+  <Choose>
+    <When Condition="'$(Configuration)' == 'Release'">
+      <PropertyGroup>
+        <PublishSingleFile>true</PublishSingleFile>
+        <SelfContained>true</SelfContained>
+        <RuntimeIdentifier Condition="$([MSBuild]::IsOSPlatform('Windows'))">win-x64</RuntimeIdentifier>
+        <RuntimeIdentifier Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux-x64</RuntimeIdentifier>
+        <!-- Ready to run makes a HUGE difference in terms of startup time. 
+             Reduces startup time from ~820ms down to ~210ms.  -->
+        <PublishReadyToRun>true</PublishReadyToRun>
+        <!-- While compression can reduce the file size by about 50%, it also almost doubles the overhead for launching the
+             interpreter (210ms -> 350-450ms) to the point where the delay becomes much more noticable.
+         -->
+        <EnableCompressionInSingleFile>false</EnableCompressionInSingleFile>
+        <!-- Can't use assembly trimming because the Prx interpreter heavily relies on reflection.
+             Interestingly, there is sufficient overlap to run  the basic prx application.
+             That means: if you are only interested in the compiler and a basic REPL, you can use a 19MB trimmed 
+             application.
+         -->
+        <PublishTrimmed>false</PublishTrimmed>
+      </PropertyGroup>
+    </When>
+  </Choose>
 
   <ItemGroup>
     <None Remove="src\prx_interactive.pxs" />
@@ -51,9 +57,6 @@
     <EmbeddedResource Include="src\prx_interactive.pxs" LogicalName="prx_interactive.pxs" />
     <EmbeddedResource Include="src\prx_lib.pxs" LogicalName="prx_lib.pxs" />
     <EmbeddedResource Include="src\prx_main.pxs" LogicalName="prx_main.pxs" />
-    <None Update="psr\_2\psr\prop.pxs">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
   
   <ItemGroup>

--- a/Prx/src/prx_interactive.pxs
+++ b/Prx/src/prx_interactive.pxs
@@ -1,33 +1,6 @@
-// Prexonite
-// 
-// Copyright (c) 2011, Christian Klauser
-// All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without modification, 
-//  are permitted provided that the following conditions are met:
-// 
-//     Redistributions of source code must retain the above copyright notice, 
-//          this list of conditions and the following disclaimer.
-//     Redistributions in binary form must reproduce the above copyright notice, 
-//          this list of conditions and the following disclaimer in the 
-//          documentation and/or other materials provided with the distribution.
-//     The names of the contributors may be used to endorse or 
-//          promote products derived from this software without specific prior written permission.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
-//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-//  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-//  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
-//  IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
 build
 {
-    require("prx_lib.pxs");
+    require("resource:Prx:prx_lib.pxs");
 }
 
 Import { System, System::Text, Prexonite, Prexonite::Compiler };

--- a/Prx/src/prx_lib.pxs
+++ b/Prx/src/prx_lib.pxs
@@ -1,29 +1,3 @@
-// Prexonite
-// 
-// Copyright (c) 2011, Christian Klauser
-// All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without modification, 
-//  are permitted provided that the following conditions are met:
-// 
-//     Redistributions of source code must retain the above copyright notice, 
-//          this list of conditions and the following disclaimer.
-//     Redistributions in binary form must reproduce the above copyright notice, 
-//          this list of conditions and the following disclaimer in the 
-//          documentation and/or other materials provided with the distribution.
-//     The names of the contributors may be used to endorse or 
-//          promote products derived from this software without specific prior written permission.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
-//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-//  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-//  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
-//  IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 namespace prx.cli
     import sys.*
 {

--- a/Prx/src/prx_main.pxs
+++ b/Prx/src/prx_main.pxs
@@ -1,34 +1,11 @@
-// Prexonite
-//
-// Copyright (c) 2011, Christian Klauser
-// All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without modification,
-//  are permitted provided that the following conditions are met:
-//
-//     Redistributions of source code must retain the above copyright notice,
-//          this list of conditions and the following disclaimer.
-//     Redistributions in binary form must reproduce the above copyright notice,
-//          this list of conditions and the following disclaimer in the
-//          documentation and/or other materials provided with the distribution.
-//     The names of the contributors may be used to endorse or
-//          promote products derived from this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-//  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-//  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-//  IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 Name prx::cli;
 Description "prx command line interface (compiler and REPL)";
 Author "Christian Klauser";
 
-build does require("prx_interactive.pxs", "prx_lib.pxs");
+build does require(
+    "resource:Prx:prx_interactive.pxs", 
+    "resource:Prx:prx_lib.pxs"
+);
 
 namespace prx.cli
     import sys.*,
@@ -40,7 +17,7 @@ namespace prx.cli
     var app; //<-- the compiled application
     var ldr; //<-- the loader used to compile 'app'
 
-    //The follwing code block is compiled as
+    //The following code block is compiled as
     // part of the initialization of the application.
     // Global variable assignments too are part of the this 'init' function.
     {

--- a/prx.sln
+++ b/prx.sln
@@ -27,7 +27,7 @@ Global
 		{A1CE6652-346C-43FE-AAC1-918C8F85DFE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A1CE6652-346C-43FE-AAC1-918C8F85DFE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1CE6652-346C-43FE-AAC1-918C8F85DFE2}.Release|Any CPU.Build.0 = Release|Any CPU
-		EndGlobalSection
+	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
Enable single-file (runtime-included) prx binary (~66MB).

Also:
 - implement reading of files from embedded resources for `build does add` and `build does require`.