### PR TITLE
PRX-63: fix NPE on `1 is true`

### DIFF
--- a/Prexonite/Compiler/Grammar/Parser.Expression.atg
+++ b/Prexonite/Compiler/Grammar/Parser.Expression.atg
@@ -252,15 +252,22 @@ PostfixUnaryExpr<out AstExpr expr>
         [ not						    (.	isInverted = true; notPosition = GetPosition(); .) 
         ]
     	TypeExpr<out type, _typeCheckShift>         
-    		                            (.  type.Arguments.Add(expr);
-    		                                expr = isInverted 
-    		                                    ? (type.CheckForPlaceholders() 
-                                                    // Special handling of "? is not Y" as that's not the same thing
-                                                    // as "not (? is Y)" when placeholders are involved.
-    		                                        ? _createPartialInvertedTypeCheck(position, type)
-    		                                        : Create.UnaryOperation(position, UnaryOperator.LogicalNot, type)
-    		                                      )
-    		                                    : type;
+    		                            (.  if (type == null)
+                                            {
+                                            	var lastPos = GetPosition();
+                                                Loader.ReportMessage(Message.Error(Resources.TypeCheck_ExpectedTypeExpression, lastPos, MessageClasses.TypeExpressionExpected));
+                                                expr = Create.Constant(GetPosition(), false);
+                                            } else {
+                                                type.Arguments.Add(expr);
+                                                expr = isInverted 
+                                                    ? (type.CheckForPlaceholders() 
+                                                        // Special handling of "? is not Y" as that's not the same thing
+                                                        // as "not (? is Y)" when placeholders are involved.
+                                                        ? _createPartialInvertedTypeCheck(position, type)
+                                                        : Create.UnaryOperation(position, UnaryOperator.LogicalNot, type)
+                                                      )
+                                                    : type;
+                                            }
     									.)
     |   inc                             (.  expr = Create.UnaryOperation(position, UnaryOperator.PostIncrement, expr); .)
     |   dec                             (.  expr = Create.UnaryOperation(position, UnaryOperator.PostDecrement, expr); .)

--- a/Prexonite/Properties/Resources.resx
+++ b/Prexonite/Properties/Resources.resx
@@ -469,4 +469,7 @@
   <data name="Parser_NsTransferSpec_Import_has_no_effect_0" xml:space="preserve">
     <value>Import of symbol `{0}` has no effect. Did you mean `{0}(*)`?</value>
   </data>
+  <data name="TypeCheck_ExpectedTypeExpression" xml:space="preserve">
+    <value>Expected type expression after `is [not]`.</value>
+  </data>
 </root>

--- a/PrexoniteTests/Tests/Compiler.Parser.cs
+++ b/PrexoniteTests/Tests/Compiler.Parser.cs
@@ -24,6 +24,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
 //  IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+using System.Linq;
 using NUnit.Framework;
 using Prexonite;
 using Prexonite.Compiler;
@@ -3899,6 +3900,16 @@ function main = invalid;
         var message = loader.Errors[0];
         Assert.That(message.MessageClass,Is.EqualTo("T.example"));
         Assert.That(message.Text,Is.EqualTo("Zhee-Error-Message"));
+    }
+
+    [Test]
+    public void OneIsTrue()
+    {
+        var ldr = _justCompile(@"
+function main = 1 is true;
+");
+        Assert.That(ldr.Errors, Is.Not.Empty);
+        Assert.That(ldr.Errors.Select(m => m.MessageClass), Contains.Item(MessageClasses.TypeExpressionExpected));
     }
 
 }


### PR DESCRIPTION
Compiler will now recover with constant `false`.

Closes PRX-63