### PR TITLE
PRX-31: forbid multiple includes of the same file

### DIFF
--- a/Prexonite/Compiler/Build/Internal/ManualTargetDescription.cs
+++ b/Prexonite/Compiler/Build/Internal/ManualTargetDescription.cs
@@ -78,7 +78,10 @@ internal class ManualTargetDescription : ITargetDescription
         return Task.Factory.StartNew(
             () =>
             {
-                var ldr = build.CreateLoader(new LoaderOptions(null, null));
+                var ldr = build.CreateLoader(new(null, null)
+                {
+                    EnforceDeterministicCodeOrder = true
+                });
 
                 var aggregateMessages = dependencies.Values
                     .SelectMany(t => t.Result.Messages);

--- a/Prexonite/Compiler/LoaderOptions.cs
+++ b/Prexonite/Compiler/LoaderOptions.cs
@@ -154,6 +154,13 @@ public class LoaderOptions
         get => _storeNewLine ?? "\n";
         set => _storeNewLine = value;
     }
+    
+    /// <summary>
+    /// If set, then `add` and `require` (transclusion) is only allowed once for each file. This ensures that
+    /// the order in which code is loaded into the module is deterministic.
+    /// </summary>
+    [PublicAPI]
+    public bool? EnforceDeterministicCodeOrder { get; set; }
 
     #endregion
 
@@ -171,5 +178,6 @@ public class LoaderOptions
         _preflightModeEnabled ??= options._preflightModeEnabled;
         _flagLiteralsEnabled ??= options._flagLiteralsEnabled;
         _storeNewLine ??= options._storeNewLine;
+        EnforceDeterministicCodeOrder ??= options.EnforceDeterministicCodeOrder;
     }
 }

--- a/Prexonite/Compiler/MessageClasses.cs
+++ b/Prexonite/Compiler/MessageClasses.cs
@@ -88,6 +88,7 @@ public static class MessageClasses
     public const string IncompleteBuiltinTypeCheck = "C.IncompleteBuiltinTypeCheck";
     public const string IncompleteBuiltinStaticCall = "C.IncompleteBuiltinStaticCall";
     public const string IncompleteBuiltinObjectCreation = "C.IncompleteBuiltinObjectCreation";
+    public const string RepeatedFileTransclusion = "C.RepeatedFileTransclusion";
 
     #endregion
 

--- a/Prexonite/Properties/Resources.resx
+++ b/Prexonite/Properties/Resources.resx
@@ -475,4 +475,10 @@
   <data name="Parser_SkeletonNamespaceRequiresSemicolon" xml:space="preserve">
     <value>Semicolon `;` required after namespace without definitons.</value>
   </data>
+  <data name="Loader_CannotRequireFileRepeatedly" xml:space="preserve">
+    <value>Cannot require file '{0}' more than once. It makes the order in which code gets loaded fragile.</value>
+  </data>
+  <data name="Loader_CannotAddFileRepeatedly" xml:space="preserve">
+    <value>Cannot add file '{0}' more than once. It makes the order in which code gets loaded fragile.</value>
+  </data>
 </root>


### PR DESCRIPTION
Goes for both `require` and `add`.

The behavior is disabled by default for PXS 1, but enabled by default for PXS 2.