### PR TITLE
Breaking: change type of FunctionDeclaration.CilImplementation

### DIFF
--- a/Prexonite/CilClosure.cs
+++ b/Prexonite/CilClosure.cs
@@ -82,11 +82,14 @@ public sealed class CilClosure : IIndirectCall, IStackAware
     /// <returns>The value returned by the function.</returns>
     public PValue IndirectCall(StackContext sctx, PValue[] args)
     {
-        if (!Function.HasCilImplementation)
+        if (Function.CilImplementation is not {} cilImplementation)
             throw new PrexoniteException("CilClosure cannot handle " + Function +
                 " because it has no cil implementation");
-        Function.CilImplementation(Function, sctx, args, SharedVariables, out var result,
-            out _);
+        
+        var callCtx = sctx.ParentApplication == Function.ParentApplication 
+            ? sctx 
+            : CilFunctionContext.New(sctx, Function);
+        cilImplementation(Function, callCtx, args, SharedVariables, out var result, out _);
         return result;
     }
 

--- a/Prexonite/CilFunctionContext.cs
+++ b/Prexonite/CilFunctionContext.cs
@@ -39,24 +39,7 @@ public sealed class CilFunctionContext : StackContext
     {
         if (originalImplementation == null)
             throw new ArgumentNullException(nameof(originalImplementation));
-        return New(caller, originalImplementation.ImportedNamespaces);
-    }
-
-    public static CilFunctionContext New(StackContext caller,
-        SymbolCollection importedNamespaces)
-    {
-        if (caller == null)
-            throw new ArgumentNullException(nameof(caller));
-
-        importedNamespaces ??= new SymbolCollection();
-
-        return new CilFunctionContext(caller.ParentEngine, caller.ParentApplication,
-            importedNamespaces);
-    }
-
-    public static CilFunctionContext New(StackContext caller)
-    {
-        return New(caller, (SymbolCollection) null);
+        return new(caller.ParentEngine, originalImplementation.ParentApplication, originalImplementation.ImportedNamespaces);
     }
 
     internal static MethodInfo NewMethod { get; } = typeof (CilFunctionContext).GetMethod(

--- a/Prexonite/Commands/Concurrency/AsyncSeq.cs
+++ b/Prexonite/Commands/Concurrency/AsyncSeq.cs
@@ -48,9 +48,6 @@ public class AsyncSeq : CoroutineCommand, ICilCompilerAware
 
     #region Overrides of PCommand
 
-    [Obsolete]
-    public override bool IsPure => false;
-
     #endregion
 
     #region Overrides of CoroutineCommand

--- a/Prexonite/Commands/Concurrency/CallAsync.cs
+++ b/Prexonite/Commands/Concurrency/CallAsync.cs
@@ -51,9 +51,6 @@ public class CallAsync : PCommand, ICilCompilerAware
 
     #region Overrides of PCommand
 
-    [Obsolete]
-    public override bool IsPure => false;
-
     public override PValue Run(StackContext sctx, PValue[] args)
     {
         return RunStatically(sctx, args);

--- a/Prexonite/Commands/Concurrency/Chan.cs
+++ b/Prexonite/Commands/Concurrency/Chan.cs
@@ -46,9 +46,6 @@ public class Chan : PCommand, ICilCompilerAware
 
     #region Overrides of PCommand
 
-    [Obsolete]
-    public override bool IsPure => false;
-
     public override PValue Run(StackContext sctx, PValue[] args)
     {
         return PType.Object.CreatePValue(new Channel());

--- a/Prexonite/Commands/Concurrency/Select.cs
+++ b/Prexonite/Commands/Concurrency/Select.cs
@@ -49,9 +49,6 @@ public class Select : PCommand, ICilCompilerAware
 
     #region Overrides of PCommand
 
-    [Obsolete]
-    public override bool IsPure => false;
-
     public override PValue Run(StackContext sctx, PValue[] args)
     {
         return RunStatically(sctx, args);

--- a/Prexonite/Commands/Core/Boxed.cs
+++ b/Prexonite/Commands/Core/Boxed.cs
@@ -43,9 +43,6 @@ public class Boxed : PCommand, ICilCompilerAware
 
     #region Overrides of PCommand
 
-    [Obsolete]
-    public override bool IsPure => false;
-
     public override PValue Run(StackContext sctx, PValue[] args)
     {
         return RunStatically(sctx, args);

--- a/Prexonite/Commands/Core/CompileToCil.cs
+++ b/Prexonite/Commands/Core/CompileToCil.cs
@@ -44,9 +44,6 @@ public class CompileToCil : PCommand, ICilCompilerAware
 
     #endregion
 
-    [Obsolete]
-    public override bool IsPure => false;
-
     public static bool AlreadyCompiledStatically { get; private set; }
 
     #region ICilCompilerAware Members
@@ -139,35 +136,7 @@ public class CompileToCil : PCommand, ICilCompilerAware
                     goto default;
                 }
             default:
-                //Compile individual functions to CIL
-                foreach (var arg in args)
-                {
-                    var T = arg.Type;
-                    PFunction func;
-                    switch (T.ToBuiltIn())
-                    {
-                        case PType.BuiltIn.String:
-                            if (
-                                !sctx.ParentApplication.Functions.TryGetValue(
-                                    (string) arg.Value, out func))
-                                continue;
-                            break;
-                        case PType.BuiltIn.Object:
-                            func = arg.Value as PFunction;
-                            if (func == null)
-                                goto default;
-                            else
-                                break;
-                        default:
-                            if (!arg.TryConvertTo(sctx, out func))
-                                continue;
-                            break;
-                    }
-
-                    Compiler.Cil.Compiler.TryCompile(func, sctx.ParentEngine,
-                        FunctionLinking.FullyIsolated);
-                }
-                break;
+                throw new PrexoniteException("Expecting 0 or 1 argument.");
         }
 
         return PType.Null;

--- a/Prexonite/Commands/Core/ConsolePrint.cs
+++ b/Prexonite/Commands/Core/ConsolePrint.cs
@@ -43,15 +43,6 @@ public class ConsolePrint : PCommand, ICilCompilerAware, ICilExtension
     #endregion
 
     /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
-
-    /// <summary>
     ///     Executes the command.
     /// </summary>
     /// <param name = "sctx">The stack context in which to execut the command.</param>

--- a/Prexonite/Commands/Core/ConsolePrintLine.cs
+++ b/Prexonite/Commands/Core/ConsolePrintLine.cs
@@ -44,15 +44,6 @@ public class ConsolePrintLine : PCommand, ICilCompilerAware, ICilExtension
     #endregion
 
     /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
-
-    /// <summary>
     ///     Executes the command.
     /// </summary>
     /// <param name = "sctx">The stack context in which to execut the command.</param>

--- a/Prexonite/Commands/Core/Debug.cs
+++ b/Prexonite/Commands/Core/Debug.cs
@@ -50,13 +50,4 @@ public class Debug : PCommand
             }
         return debugging;
     }
-
-    /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
 }

--- a/Prexonite/Commands/Core/Meta.cs
+++ b/Prexonite/Commands/Core/Meta.cs
@@ -63,15 +63,6 @@ public class Meta : PCommand, ICilCompilerAware
     #endregion
 
     /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
-
-    /// <summary>
     ///     Executes the command.
     /// </summary>
     /// <param name = "sctx">The stack context in which to execut the command.</param>

--- a/Prexonite/Commands/Core/Not.cs
+++ b/Prexonite/Commands/Core/Not.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Prexonite.Types;
+﻿using Prexonite.Types;
 
 namespace Prexonite.Commands.Core;
 
@@ -10,9 +9,6 @@ public class Not : PCommand
     private Not()
     {
     }
-
-    [Obsolete("IsPure mechanism was abandoned in v1.2. Use ICilExtension to perform constant folding instead.")]
-    public override bool IsPure => true;
 
     public override PValue Run(StackContext sctx, PValue[] args)
     {

--- a/Prexonite/Commands/Core/PartialApplication/ThenCommand.cs
+++ b/Prexonite/Commands/Core/PartialApplication/ThenCommand.cs
@@ -43,9 +43,6 @@ public class ThenCommand : PCommand, ICilCompilerAware
 
     #region Overrides of PCommand
 
-    [Obsolete]
-    public override bool IsPure => false;
-
     public override PValue Run(StackContext sctx, PValue[] args)
     {
         return RunStatically(sctx, args);

--- a/Prexonite/Commands/Core/Print.cs
+++ b/Prexonite/Commands/Core/Print.cs
@@ -53,15 +53,6 @@ public class DynamicPrint : PCommand
     }
 
     /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
-
-    /// <summary>
     ///     Prints all arguments.
     /// </summary>
     /// <param name = "sctx">The context in which to convert the arguments to strings.</param>

--- a/Prexonite/Commands/Core/PrintLine.cs
+++ b/Prexonite/Commands/Core/PrintLine.cs
@@ -53,15 +53,6 @@ public class DynamicPrintLine : PCommand
     }
 
     /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
-
-    /// <summary>
     ///     Prints all arguments and appends a NewLine.
     /// </summary>
     /// <param name = "sctx">The context in which to convert the arguments to strings.</param>

--- a/Prexonite/Commands/Core/StaticPrint.cs
+++ b/Prexonite/Commands/Core/StaticPrint.cs
@@ -53,15 +53,6 @@ public class StaticPrint : PCommand, ICilCompilerAware, ICilExtension
     #endregion
 
     /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
-
-    /// <summary>
     ///     Executes the command.
     /// </summary>
     /// <param name = "sctx">The stack context in which to execut the command.</param>

--- a/Prexonite/Commands/Core/StaticPrintLine.cs
+++ b/Prexonite/Commands/Core/StaticPrintLine.cs
@@ -45,15 +45,6 @@ public class StaticPrintLine : PCommand, ICilCompilerAware, ICilExtension
     #endregion
 
     /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
-
-    /// <summary>
     ///     Executes the command.
     /// </summary>
     /// <param name = "sctx">The stack context in which to execut the command.</param>

--- a/Prexonite/Commands/Lazy/AsThunkCommand.cs
+++ b/Prexonite/Commands/Lazy/AsThunkCommand.cs
@@ -46,9 +46,6 @@ public class AsThunkCommand : PCommand, ICilCompilerAware
 
     #region Overrides of PCommand
 
-    [Obsolete]
-    public override bool IsPure => false;
-
     public override PValue Run(StackContext sctx, PValue[] args)
     {
         return RunStatically(sctx, args);

--- a/Prexonite/Commands/Lazy/ForceCommand.cs
+++ b/Prexonite/Commands/Lazy/ForceCommand.cs
@@ -44,9 +44,6 @@ public class ForceCommand : PCommand, ICilCompilerAware
 
     #region Overrides of PCommand
 
-    [Obsolete]
-    public override bool IsPure => false;
-
     public override PValue Run(StackContext sctx, PValue[] args)
     {
         return RunStatically(sctx, args);

--- a/Prexonite/Commands/Lazy/ThunkCommand.cs
+++ b/Prexonite/Commands/Lazy/ThunkCommand.cs
@@ -45,9 +45,6 @@ public class ThunkCommand : PCommand, ICilCompilerAware
 
     #endregion
 
-    [Obsolete]
-    public override bool IsPure => false;
-
     public override PValue Run(StackContext sctx, PValue[] args)
     {
         return RunStatically(sctx, args);

--- a/Prexonite/Commands/Lazy/ToSeqCommand.cs
+++ b/Prexonite/Commands/Lazy/ToSeqCommand.cs
@@ -45,9 +45,6 @@ public class ToSeqCommand : CoroutineCommand, ICilCompilerAware
 
     #region Overrides of PCommand
 
-    [Obsolete]
-    public override bool IsPure => false;
-
     #endregion
 
     #region Overrides of CoroutineCommand

--- a/Prexonite/Commands/List/All.cs
+++ b/Prexonite/Commands/List/All.cs
@@ -45,15 +45,6 @@ public sealed class All : PCommand, ICilCompilerAware
     #endregion
 
     /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
-
-    /// <summary>
     ///     Executes the command.
     /// </summary>
     /// <param name = "sctx">The stack context in which to execut the command.</param>

--- a/Prexonite/Commands/List/Append.cs
+++ b/Prexonite/Commands/List/Append.cs
@@ -42,9 +42,6 @@ public class Append : CoroutineCommand, ICilCompilerAware
 
     #endregion
 
-    [Obsolete]
-    public override bool IsPure => false;
-
     protected override IEnumerable<PValue> CoroutineRun(ContextCarrier sctxCarrier,
         PValue[] args)
     {

--- a/Prexonite/Commands/List/Count.cs
+++ b/Prexonite/Commands/List/Count.cs
@@ -41,15 +41,6 @@ public class Count : PCommand, ICilCompilerAware
     #endregion
 
     /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
-
-    /// <summary>
     ///     Executes the command.
     /// </summary>
     /// <param name = "sctx">The stack context in which to execut the command.</param>

--- a/Prexonite/Commands/List/Distinct.cs
+++ b/Prexonite/Commands/List/Distinct.cs
@@ -55,13 +55,4 @@ public class Distinct : CoroutineCommand
                 }
         }
     }
-
-    /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
 }

--- a/Prexonite/Commands/List/Each.cs
+++ b/Prexonite/Commands/List/Each.cs
@@ -74,15 +74,6 @@ public class Each : PCommand, ICilCompilerAware
         return PType.Null;
     }
 
-    /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
-
     #region ICilCompilerAware Members
 
     CompilationFlags ICilCompilerAware.CheckQualification(Instruction ins)

--- a/Prexonite/Commands/List/Except.cs
+++ b/Prexonite/Commands/List/Except.cs
@@ -79,15 +79,6 @@ public class Except : PCommand, ICilCompilerAware
         return sctx.CreateNativePValue(t.Keys);
     }
 
-    /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
-
     #region ICilCompilerAware Members
 
     /// <summary>

--- a/Prexonite/Commands/List/Exists.cs
+++ b/Prexonite/Commands/List/Exists.cs
@@ -60,13 +60,4 @@ public class Exists : PCommand
 
         return false;
     }
-
-    /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
 }

--- a/Prexonite/Commands/List/FoldL.cs
+++ b/Prexonite/Commands/List/FoldL.cs
@@ -116,15 +116,6 @@ public class FoldL : PCommand, ICilCompilerAware
         return RunStatically(sctx, args);
     }
 
-    /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false; //indirect call
-
     #region ICilCompilerAware Members
 
     /// <summary>

--- a/Prexonite/Commands/List/FoldR.cs
+++ b/Prexonite/Commands/List/FoldR.cs
@@ -121,15 +121,6 @@ public class FoldR : PCommand, ICilCompilerAware
         return Run(sctx, f, left, source);
     }
 
-    /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false; //use of indirect call
-
     #region ICilCompilerAware Members
 
     /// <summary>

--- a/Prexonite/Commands/List/ForAll.cs
+++ b/Prexonite/Commands/List/ForAll.cs
@@ -60,13 +60,4 @@ public class ForAll : PCommand
 
         return true;
     }
-
-    /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
 }

--- a/Prexonite/Commands/List/Frequency.cs
+++ b/Prexonite/Commands/List/Frequency.cs
@@ -58,13 +58,4 @@ public class Frequency : CoroutineCommand
         foreach (var pair in t)
             yield return new PValueKeyValuePair(pair.Key, pair.Value);
     }
-
-    /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
 }

--- a/Prexonite/Commands/List/GroupBy.cs
+++ b/Prexonite/Commands/List/GroupBy.cs
@@ -78,13 +78,4 @@ public class GroupBy : CoroutineCommand
         }
         // ReSharper restore LoopCanBeConvertedToQuery
     }
-
-    /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
 }

--- a/Prexonite/Commands/List/HeadTail.cs
+++ b/Prexonite/Commands/List/HeadTail.cs
@@ -42,9 +42,6 @@ public class HeadTail : PCommand, ICilCompilerAware
 
     #endregion
 
-    [Obsolete]
-    public override bool IsPure => false;
-
     public override PValue Run(StackContext sctx, PValue[] args)
     {
         return RunStatically(sctx, args);

--- a/Prexonite/Commands/List/Intersect.cs
+++ b/Prexonite/Commands/List/Intersect.cs
@@ -79,13 +79,4 @@ public class Intersect : CoroutineCommand
                     yield return x;
             }
     }
-
-    /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
 }

--- a/Prexonite/Commands/List/Limit.cs
+++ b/Prexonite/Commands/List/Limit.cs
@@ -90,15 +90,6 @@ public class Limit : CoroutineCommand, ICilCompilerAware
         return sctx.CreateNativePValue(new Coroutine(corctx));
     }
 
-    /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
-
     #region ICilCompilerAware Members
 
     /// <summary>

--- a/Prexonite/Commands/List/List.cs
+++ b/Prexonite/Commands/List/List.cs
@@ -44,15 +44,6 @@ public class List : PCommand, ICilCompilerAware
     #endregion
 
     /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
-
-    /// <summary>
     ///     Executes the command.
     /// </summary>
     /// <param name = "sctx">The stack context in which to execut the command.</param>

--- a/Prexonite/Commands/List/Map.cs
+++ b/Prexonite/Commands/List/Map.cs
@@ -194,15 +194,6 @@ public class Map : CoroutineCommand, ICilCompilerAware
         return sctx.CreateNativePValue(new Coroutine(corctx));
     }
 
-    /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
-
     #region ICilCompilerAware Members
 
     /// <summary>

--- a/Prexonite/Commands/List/Range.cs
+++ b/Prexonite/Commands/List/Range.cs
@@ -99,15 +99,6 @@ public class Range : CoroutineCommand, ICilCompilerAware
         return sctx.CreateNativePValue(new Coroutine(corctx));
     }
 
-    /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
-
     public static Range Instance { get; } = new();
 
     #region ICilCompilerAware Members

--- a/Prexonite/Commands/List/Reverse.cs
+++ b/Prexonite/Commands/List/Reverse.cs
@@ -77,15 +77,6 @@ public class Reverse : CoroutineCommand, ICilCompilerAware
         return sctx.CreateNativePValue(new Coroutine(corctx));
     }
 
-    /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
-
     #region ICilCompilerAware Members
 
     /// <summary>

--- a/Prexonite/Commands/List/Skip.cs
+++ b/Prexonite/Commands/List/Skip.cs
@@ -89,15 +89,6 @@ public class Skip : CoroutineCommand, ICilCompilerAware
         return sctx.CreateNativePValue(new Coroutine(corctx));
     }
 
-    /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
-
     #region ICilCompilerAware Members
 
     /// <summary>

--- a/Prexonite/Commands/List/Sort.cs
+++ b/Prexonite/Commands/List/Sort.cs
@@ -93,14 +93,5 @@ public class Sort : PCommand
         }
     }
 
-    /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false; //The function makes heavy use indirect call, 
-
     //which might lead to initialization of the application.
 }

--- a/Prexonite/Commands/List/Sum.cs
+++ b/Prexonite/Commands/List/Sum.cs
@@ -43,9 +43,6 @@ public class Sum : PCommand, ICilCompilerAware
 
     #endregion
 
-    [Obsolete]
-    public override bool IsPure => false;
-
     public override PValue Run(StackContext sctx, PValue[] args)
     {
         return RunStatically(sctx, args);

--- a/Prexonite/Commands/List/TakeWhile.cs
+++ b/Prexonite/Commands/List/TakeWhile.cs
@@ -92,15 +92,6 @@ public class TakeWhile : CoroutineCommand, ICilCompilerAware
         return sctx.CreateNativePValue(new Coroutine(corctx));
     }
 
-    /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
-
     #region ICilCompilerAware Members
 
     /// <summary>

--- a/Prexonite/Commands/List/Where.cs
+++ b/Prexonite/Commands/List/Where.cs
@@ -100,15 +100,6 @@ public class Where : CoroutineCommand, ICilCompilerAware
         return sctx.CreateNativePValue(new Coroutine(corctx));
     }
 
-    /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => false;
-
     #region ICilCompilerAware Members
 
     /// <summary>

--- a/Prexonite/Commands/Math/Abs.cs
+++ b/Prexonite/Commands/Math/Abs.cs
@@ -43,15 +43,6 @@ public sealed class Abs : PCommand, ICilCompilerAware
 
     #endregion
 
-    /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => true;
-
 
     /// <summary>
     ///     Executes the command.

--- a/Prexonite/Commands/Math/Ceiling.cs
+++ b/Prexonite/Commands/Math/Ceiling.cs
@@ -43,15 +43,6 @@ public class Ceiling : PCommand, ICilCompilerAware
     #endregion
 
     /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => true;
-
-    /// <summary>
     ///     Executes the command.
     /// </summary>
     /// <param name = "sctx">The stack context in which to execut the command.</param>

--- a/Prexonite/Commands/Math/Cos.cs
+++ b/Prexonite/Commands/Math/Cos.cs
@@ -43,15 +43,6 @@ public class Cos : PCommand, ICilCompilerAware
     #endregion
 
     /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => true;
-
-    /// <summary>
     ///     Executes the command.
     /// </summary>
     /// <param name = "sctx">The stack context in which to execut the command.</param>

--- a/Prexonite/Commands/Math/Exp.cs
+++ b/Prexonite/Commands/Math/Exp.cs
@@ -43,15 +43,6 @@ public class Exp : PCommand, ICilCompilerAware
     #endregion
 
     /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => true;
-
-    /// <summary>
     ///     Executes the command.
     /// </summary>
     /// <param name = "sctx">The stack context in which to execut the command.</param>

--- a/Prexonite/Commands/Math/Floor.cs
+++ b/Prexonite/Commands/Math/Floor.cs
@@ -43,15 +43,6 @@ public class Floor : PCommand, ICilCompilerAware
     #endregion
 
     /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => true;
-
-    /// <summary>
     ///     Executes the command.
     /// </summary>
     /// <param name = "sctx">The stack context in which to execut the command.</param>

--- a/Prexonite/Commands/Math/Log.cs
+++ b/Prexonite/Commands/Math/Log.cs
@@ -43,15 +43,6 @@ public class Log : PCommand, ICilCompilerAware
     #endregion
 
     /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => true;
-
-    /// <summary>
     ///     Executes the command.
     /// </summary>
     /// <param name = "sctx">The stack context in which to execut the command.</param>

--- a/Prexonite/Commands/Math/Max.cs
+++ b/Prexonite/Commands/Math/Max.cs
@@ -44,15 +44,6 @@ public class Max : PCommand, ICilCompilerAware
     #endregion
 
     /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => true;
-
-    /// <summary>
     ///     Executes the command.
     /// </summary>
     /// <param name = "sctx">The stack context in which to execut the command.</param>

--- a/Prexonite/Commands/Math/Min.cs
+++ b/Prexonite/Commands/Math/Min.cs
@@ -44,15 +44,6 @@ public class Min : PCommand, ICilCompilerAware
     #endregion
 
     /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => true;
-
-    /// <summary>
     ///     Executes the command.
     /// </summary>
     /// <param name = "sctx">The stack context in which to execut the command.</param>

--- a/Prexonite/Commands/Math/Pi.cs
+++ b/Prexonite/Commands/Math/Pi.cs
@@ -23,7 +23,7 @@
 //  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
 //  IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-using System;
+
 using System.Reflection.Emit;
 using Prexonite.Compiler.Cil;
 
@@ -40,15 +40,6 @@ public class Pi : PCommand, ICilCompilerAware
     public static Pi Instance { get; } = new();
 
     #endregion
-
-    /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => true;
 
     /// <summary>
     ///     Executes the command.

--- a/Prexonite/Commands/Math/Round.cs
+++ b/Prexonite/Commands/Math/Round.cs
@@ -44,15 +44,6 @@ public class Round : PCommand, ICilCompilerAware
     #endregion
 
     /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => true;
-
-    /// <summary>
     ///     Executes the command.
     /// </summary>
     /// <param name = "sctx">The stack context in which to execut the command.</param>

--- a/Prexonite/Commands/Math/Sin.cs
+++ b/Prexonite/Commands/Math/Sin.cs
@@ -43,15 +43,6 @@ public class Sin : PCommand, ICilCompilerAware
     #endregion
 
     /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => true;
-
-    /// <summary>
     ///     Executes the command.
     /// </summary>
     /// <param name = "sctx">The stack context in which to execut the command.</param>

--- a/Prexonite/Commands/Math/Sqrt.cs
+++ b/Prexonite/Commands/Math/Sqrt.cs
@@ -43,15 +43,6 @@ public class Sqrt : PCommand, ICilCompilerAware
     #endregion
 
     /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => true;
-
-    /// <summary>
     ///     Executes the command.
     /// </summary>
     /// <param name = "sctx">The stack context in which to execut the command.</param>

--- a/Prexonite/Commands/Math/Tan.cs
+++ b/Prexonite/Commands/Math/Tan.cs
@@ -43,15 +43,6 @@ public class Tan : PCommand, ICilCompilerAware
     #endregion
 
     /// <summary>
-    ///     A flag indicating whether the command acts like a pure function.
-    /// </summary>
-    /// <remarks>
-    ///     Pure commands can be applied at compile time.
-    /// </remarks>
-    [Obsolete]
-    public override bool IsPure => true;
-
-    /// <summary>
     ///     Executes the command.
     /// </summary>
     /// <param name = "sctx">The stack context in which to execut the command.</param>

--- a/Prexonite/Commands/PCommand.cs
+++ b/Prexonite/Commands/PCommand.cs
@@ -41,59 +41,6 @@ public abstract class PCommand : IIndirectCall
     /// <returns>The value returned by the command. Must not be null. (But possibly {null~Null})</returns>
     public abstract PValue Run(StackContext sctx, PValue[] args);
 
-    [Obsolete(
-        "IsPure mechanism was abandoned in v1.2. Use ICilExtension to perform constant folding instead."
-    )]
-    // ReSharper disable UnusedMember.Global
-    // ReSharper disable VirtualMemberNeverOverriden.Global
-    public virtual bool IsPure
-        // ReSharper restore VirtualMemberNeverOverriden.Global
-        =>
-            false; // ReSharper restore UnusedMember.Global
-
-    #region Command groups
-
-    /// <summary>
-    ///     A bit fields that represents memberships in the <see cref = "PCommandGroups" />.
-    /// </summary>
-    public PCommandGroups Groups { get; private set; } = PCommandGroups.None;
-
-    /// <summary>
-    ///     Indicates whether the command belongs to a group.
-    /// </summary>
-    public bool BelongsToAGroup => Groups != PCommandGroups.None;
-
-    /// <summary>
-    ///     Determines whether the command is a member of a particular group.
-    /// </summary>
-    /// <param name = "groups">The group (or groups) to test the command for.</param>
-    /// <returns>True, if the command is a member of the supplied group (or all groups); false otherwise.</returns>
-    public bool IsInGroup(PCommandGroups groups)
-    {
-        return (Groups & groups) == Groups;
-        //If _groups contains groups, an AND operation won't alter it
-    }
-
-    /// <summary>
-    ///     Adds the command to the supplied group (or groups).
-    /// </summary>
-    /// <param name = "additionalGroups">The group (or groups) to which to add the command.</param>
-    public void AddToGroup(PCommandGroups additionalGroups)
-    {
-        Groups = Groups | additionalGroups;
-    }
-
-    /// <summary>
-    ///     Removes the command from the supplied group (or groups)
-    /// </summary>
-    /// <param name = "groups">The group (or groups) from which to remove the command.</param>
-    public void RemoveFromGroup(PCommandGroups groups)
-    {
-        Groups = Groups ^ (Groups & groups);
-    }
-
-    #endregion
-
     #region IIndirectCall Members
 
     /// <summary>

--- a/Prexonite/Commands/Text/SetCenterCommand.cs
+++ b/Prexonite/Commands/Text/SetCenterCommand.cs
@@ -42,9 +42,6 @@ public class SetCenterCommand : PCommand, ICilCompilerAware
 
     #endregion
 
-    [Obsolete]
-    public override bool IsPure => true;
-
     public static PValue RunStatically(StackContext sctx, PValue[] args)
     {
         // function setright(w,s,f)

--- a/Prexonite/Commands/Text/SetLeftCommand.cs
+++ b/Prexonite/Commands/Text/SetLeftCommand.cs
@@ -42,9 +42,6 @@ public class SetLeftCommand : PCommand, ICilCompilerAware
 
     #endregion
 
-    [Obsolete]
-    public override bool IsPure => true;
-
     public static PValue RunStatically(StackContext sctx, PValue[] args)
     {
         // function setright(w,s,f)

--- a/Prexonite/Commands/Text/SetRightCommand.cs
+++ b/Prexonite/Commands/Text/SetRightCommand.cs
@@ -42,9 +42,6 @@ public class SetRightCommand : PCommand, ICilCompilerAware
 
     #endregion
 
-    [Obsolete]
-    public override bool IsPure => true;
-
     public static PValue RunStatically(StackContext sctx, PValue[] args)
     {
         // function setright(w,s,f)

--- a/Prexonite/Compiler/Build/BuildExtensions.cs
+++ b/Prexonite/Compiler/Build/BuildExtensions.cs
@@ -34,7 +34,7 @@ public static class BuildExtensions
 {
     public static ITarget Build(this IPlan plan, ModuleName name)
     {
-        return plan.BuildAsync(name).Result;
+        return plan.BuildAsync(name).GetAwaiter().GetResult();
     }
 
     public static Task<ITarget> BuildAsync(this IPlan plan, ModuleName name)
@@ -42,10 +42,10 @@ public static class BuildExtensions
         return plan.BuildAsync(name, CancellationToken.None);
     }
 
-    public static Tuple<Application,ITarget> Load(this IPlan plan, ModuleName name)
+    public static (Application Application, ITarget Target) Load(this IPlan plan, ModuleName name)
     {
         var loadTask = plan.LoadAsync(name, CancellationToken.None);
-        return loadTask.Result;
+        return loadTask.GetAwaiter().GetResult();
     }
 
     public static Application LoadApplication(this IPlan plan, ModuleName name)
@@ -68,6 +68,6 @@ public static class BuildExtensions
 
     public static ITargetDescription Assemble(this ISelfAssemblingPlan plan, ISource source)
     {
-        return plan.AssembleAsync(source, CancellationToken.None).Result;
+        return plan.AssembleAsync(source, CancellationToken.None).GetAwaiter().GetResult();
     }
 }

--- a/Prexonite/Compiler/Build/IPlan.cs
+++ b/Prexonite/Compiler/Build/IPlan.cs
@@ -57,11 +57,11 @@ public interface IPlan
         BuildAsync(name.Singleton(), token)[name];
 
     [NotNull]
-    Task<Tuple<Application, ITarget>> LoadAsync([NotNull] ModuleName name, CancellationToken token) => 
+    Task<(Application Application, ITarget Target)> LoadAsync([NotNull] ModuleName name, CancellationToken token) => 
         LoadAsync(name.Singleton(), token)[name];
 
     [NotNull]
-    IDictionary<ModuleName, Task<Tuple<Application,ITarget>>> LoadAsync([NotNull] IEnumerable<ModuleName> names, CancellationToken token);
+    IDictionary<ModuleName, Task<(Application Application, ITarget Target)>> LoadAsync([NotNull] IEnumerable<ModuleName> names, CancellationToken token);
 
     [CanBeNull]
     LoaderOptions Options { get; set; }

--- a/Prexonite/Compiler/Build/ManualPlan.cs
+++ b/Prexonite/Compiler/Build/ManualPlan.cs
@@ -28,8 +28,8 @@ public class ManualPlan : IPlan
         public Engine Create() =>
             _inner.Options?.ParentEngine switch
             {
-                { } x => new Engine(x),
-                _ => new Engine()
+                { } x => new(x),
+                _ => new()
             };
 
         public bool Return(Engine obj) => true;
@@ -101,7 +101,7 @@ public class ManualPlan : IPlan
         return new(5, TargetDescriptions.Count);
     }
 
-    public IDictionary<ModuleName, Task<Tuple<Application, ITarget>>> LoadAsync(IEnumerable<ModuleName> names, CancellationToken token)
+    public IDictionary<ModuleName, Task<(Application Application, ITarget Target)>> LoadAsync(IEnumerable<ModuleName> names, CancellationToken token)
     {
         if (names == null)
             throw new ArgumentNullException(nameof(names));
@@ -114,7 +114,7 @@ public class ManualPlan : IPlan
                 var target = buildTask.Result;
                 var app = new Application(target.Module);
                 _linkDependencies(taskMap, app, description, token);
-                return Tuple.Create(app, target);
+                return (app, target);
             }, token);
         });
     }

--- a/Prexonite/Compiler/Cil/CilSymbol.cs
+++ b/Prexonite/Compiler/Cil/CilSymbol.cs
@@ -41,13 +41,9 @@ public class CilSymbol
         Kind = kind;
     }
 
-    public SymbolKind Kind { [DebuggerStepThrough]
-        get; [DebuggerStepThrough]
-        set; }
+    public SymbolKind Kind { get; set; }
 
-    public LocalBuilder Local { [DebuggerStepThrough]
-        get; [DebuggerStepThrough]
-        set; }
+    public LocalBuilder Local { get; set; }
 
     public void EmitLoad(CompilerState state)
     {
@@ -60,6 +56,8 @@ public class CilSymbol
                 state.EmitLoadLocal(Local.LocalIndex);
                 state.Il.EmitCall(OpCodes.Call, Compiler.GetValueMethod, null);
                 break;
+            default:
+                throw new PrexoniteException("Internal error: cannot emit load for enumeration variable.");
         }
     }
 }

--- a/Prexonite/Compiler/Cil/ICilImplementation.cs
+++ b/Prexonite/Compiler/Cil/ICilImplementation.cs
@@ -1,0 +1,10 @@
+#nullable enable
+using System.Reflection;
+
+namespace Prexonite.Compiler.Cil;
+
+public interface ICilImplementation
+{
+    MethodInfo Declaration { get; }
+    CilFunction Implementation { get; }
+}

--- a/Prexonite/FunctionContext.cs
+++ b/Prexonite/FunctionContext.cs
@@ -926,9 +926,12 @@ public class FunctionContext : StackContext
                         _fetchReturnValue = !justEffect;
                         ParentEngine.Stack.AddLast(fctx);
 #else
-                    if (func.HasCilImplementation)
+                    if (func.CilImplementation is {} cilImplementation)
                     {
-                        func.CilImplementation(func, this, argv, null, out left, out var returnMode);
+                        var callCtx = ParentApplication == func.ParentApplication 
+                            ? this 
+                            : (StackContext) CilFunctionContext.New(this, func);
+                        cilImplementation(func, callCtx, argv, null, out left, out var returnMode);
                         ReturnMode = returnMode;
                         if (!justEffect)
                             Push(left);

--- a/Prexonite/Helper/DependencyAnalysis.cs
+++ b/Prexonite/Helper/DependencyAnalysis.cs
@@ -29,6 +29,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Prexonite.Types;
 
@@ -116,6 +117,7 @@ public class DependencyAnalysis<TKey, TValue> where
         }
     }
 
+    [return: NotNull]
     public IEnumerable<Group> GetMutuallyRecursiveGroups()
     {
         var env = new SearchEnv();

--- a/Prexonite/Helper/LastAccessCache.cs
+++ b/Prexonite/Helper/LastAccessCache.cs
@@ -72,11 +72,6 @@ public class LastAccessCache<T> : IObjectCache<T>
         return name;
     }
 
-    public int EstimateSize()
-    {
-        return _accessOrder.Count;
-    }
-
     private void _insert(T name)
     {
         if (_accessOrder.Count > Capacity*2)
@@ -105,9 +100,17 @@ public class LastAccessCache<T> : IObjectCache<T>
     protected IEnumerable<T> Contents()
     {
         lock (_pointerTable)
-            foreach (var item in _accessOrder.InReverse())
-                yield return item;
+            return _accessOrder.InReverse().ToList();
     }
 
-    protected int Count => _accessOrder.Count;
+    protected int Count
+    {
+        get
+        {
+            lock (_accessOrder)
+            {
+                return _accessOrder.Count;
+            }
+        }
+    }
 }

--- a/Prexonite/Helper/Metatable.cs
+++ b/Prexonite/Helper/Metatable.cs
@@ -231,7 +231,7 @@ public abstract class MetaTable : ISymbolTable<MetaEntry>, IMetaFilter, ICloneab
         key = GetTransform(key);
         if (TryGetValueTransformed(key, out value))
             return true;
-        value = DefaultValue;
+        value = default;
         return false;
     }
 

--- a/Prexonite/Modular/FunctionDeclaration.cs
+++ b/Prexonite/Modular/FunctionDeclaration.cs
@@ -31,6 +31,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Text;
+using JetBrains.Annotations;
 using Prexonite.Compiler;
 using Prexonite.Compiler.Cil;
 using Prexonite.Types;
@@ -151,7 +152,8 @@ public abstract class FunctionDeclaration : IHasMetaTable, IMetaFilter, IDepende
     /// </summary>
     [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly",
         MessageId = "Cil")]
-    public abstract CilFunction CilImplementation { get; protected internal set; }
+    [CanBeNull]
+    public abstract ICilImplementation CilImplementation { get; protected internal set; }
 
     [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly",
         MessageId = "Cil")]
@@ -171,6 +173,7 @@ public abstract class FunctionDeclaration : IHasMetaTable, IMetaFilter, IDepende
     /// The name this function was originally declared under. 
     /// Primarily a debugging help, has no meaning in the Prexonite VM.
     /// </summary>
+    [PublicAPI]
     public string LogicalId
     {
         [DebuggerStepThrough]
@@ -329,7 +332,7 @@ public abstract class FunctionDeclaration : IHasMetaTable, IMetaFilter, IDepende
 
         public sealed override SymbolTable<int> LocalVariableMapping { get; protected set; }
 
-        public override CilFunction CilImplementation { get; protected internal set; }
+        public override ICilImplementation CilImplementation { get; protected internal set; }
 
         public override ReadOnlyCollection<TryCatchFinallyBlock> TryCatchFinallyBlocks
         {

--- a/Prexonite/Modular/ModuleSymbolTable.cs
+++ b/Prexonite/Modular/ModuleSymbolTable.cs
@@ -1,0 +1,136 @@
+#nullable enable
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Prexonite.Modular;
+
+public interface IModuleSymbolTable<T> : IDictionary<(ModuleName ModuleName, string Id), T>
+{
+    T this[ModuleName moduleName, string id] { get; set; }
+    void Add(ModuleName moduleName, string id, T value);
+    bool Remove(ModuleName moduleName, string id);
+    bool TryGetValue(ModuleName moduleName, string id, [MaybeNullWhen(false)] out T value);
+}
+
+public class ModuleSymbolTable<T> : IModuleSymbolTable<T>
+{
+    private readonly Dictionary<(ModuleName ModuleName, string Id), T> _inner;
+
+    public ModuleSymbolTable()
+    {
+        _inner = new(new ModuleSymbolTableEqualityComparer());
+    }
+
+    public ModuleSymbolTable(int capacity)
+    {
+        _inner = new(capacity, new ModuleSymbolTableEqualityComparer());
+    }
+
+    private class ModuleSymbolTableEqualityComparer : IEqualityComparer<(ModuleName ModuleName, string Id)>
+    {
+        public bool Equals((ModuleName ModuleName, string Id) x, (ModuleName ModuleName, string Id) y)
+        {
+            return x.ModuleName == y.ModuleName && Engine.DefaultStringComparer.Compare(x.Id, y.Id) == 0;
+        }
+
+        public int GetHashCode((ModuleName, string) obj)
+        {
+            return obj.Item1.GetHashCode() ^ obj.Item2.GetHashCode();
+        }
+    }
+
+    public T this[ModuleName moduleName, string id]
+    {
+        get => _inner[(moduleName, id)];
+        set => _inner[(moduleName, id)] = value;
+    }
+
+    public void Add(ModuleName moduleName, string id, T value)
+    {
+        _inner.Add((moduleName, id), value);
+    }
+
+    public bool Remove(ModuleName moduleName, string id)
+    {
+        return _inner.Remove((moduleName, id));
+    }
+
+    public bool TryGetValue(ModuleName moduleName, string id, [MaybeNullWhen(false)] out T value)
+    {
+        return _inner.TryGetValue((moduleName, id), out value);
+    }
+
+    # region IDictionary`2 implemetation
+
+    public IEnumerator<KeyValuePair<(ModuleName ModuleName, string Id), T>> GetEnumerator()
+    {
+        return _inner.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return ((IEnumerable)_inner).GetEnumerator();
+    }
+
+    public void Add(KeyValuePair<(ModuleName ModuleName, string Id), T> item)
+    {
+        ((IDictionary<(ModuleName ModuleName, string Id), T>)_inner).Add(item);
+    }
+
+    public void Clear()
+    {
+        _inner.Clear();
+    }
+
+    public bool Contains(KeyValuePair<(ModuleName ModuleName, string Id), T> item)
+    {
+        return ((IDictionary<(ModuleName ModuleName, string Id), T>)_inner).Contains(item);
+    }
+
+    public void CopyTo(KeyValuePair<(ModuleName ModuleName, string Id), T>[] array, int arrayIndex)
+    {
+        ((IDictionary<(ModuleName ModuleName, string Id), T>)_inner).CopyTo(array, arrayIndex);
+    }
+
+    public bool Remove(KeyValuePair<(ModuleName ModuleName, string Id), T> item)
+    {
+        return ((IDictionary<(ModuleName ModuleName, string Id), T>)_inner).Remove(item);
+    }
+
+    public int Count => _inner.Count;
+
+    public bool IsReadOnly => ((IDictionary<(ModuleName ModuleName, string Id), T>)_inner).IsReadOnly;
+
+    public void Add((ModuleName ModuleName, string Id) key, T value)
+    {
+        _inner.Add(key, value);
+    }
+
+    public bool ContainsKey((ModuleName ModuleName, string Id) key)
+    {
+        return _inner.ContainsKey(key);
+    }
+
+    public bool Remove((ModuleName ModuleName, string Id) key)
+    {
+        return _inner.Remove(key);
+    }
+
+    public bool TryGetValue((ModuleName ModuleName, string Id) key, [MaybeNullWhen(false)] out T value)
+    {
+        return _inner.TryGetValue(key, out value);
+    }
+
+    public T this[(ModuleName ModuleName, string Id) key]
+    {
+        get => _inner[key];
+        set => _inner[key] = value;
+    }
+
+    public ICollection<(ModuleName ModuleName, string Id)> Keys => _inner.Keys;
+
+    public ICollection<T> Values => _inner.Values;
+
+    #endregion
+}

--- a/Prexonite/PFunction.cs
+++ b/Prexonite/PFunction.cs
@@ -162,14 +162,6 @@ public class  PFunction : IHasMetaTable,
     }
 
     /// <summary>
-    ///     Updates the mapping of local names.
-    /// </summary>
-    internal void CreateLocalVariableMapping()
-    {
-        Declaration.CreateLocalVariableMapping();
-    }
-
-    /// <summary>
     ///     The table that maps indices to local names.
     /// </summary>
     public SymbolTable<int> LocalVariableMapping
@@ -178,7 +170,7 @@ public class  PFunction : IHasMetaTable,
         get => Declaration.LocalVariableMapping;
     }
 
-    public CilFunction CilImplementation => Declaration.CilImplementation;
+    public CilFunction? CilImplementation => Declaration.CilImplementation?.Implementation;
 
     public bool HasCilImplementation => Declaration.HasCilImplementation;
 
@@ -318,17 +310,17 @@ public class  PFunction : IHasMetaTable,
     [PublicAPI]
     public PValue Run(Engine engine, PValue[]? args, PVariable[]? sharedVariables)
     {
-        if (HasCilImplementation)
+        if (CilImplementation is {} cilImplementation)
         {
             //Fix #8
             ParentApplication.EnsureInitialization(engine);
-            CilImplementation
+            cilImplementation
             (
                 this,
                 new NullContext(engine, ParentApplication, ImportedNamespaces),
                 args,
                 sharedVariables,
-                out PValue result, out _);
+                out var result, out _);
             return result;
         }
         else

--- a/PrexoniteTests/Tests/Configurations/ModuleCache.cs
+++ b/PrexoniteTests/Tests/Configurations/ModuleCache.cs
@@ -1,74 +1,61 @@
-﻿// Prexonite
-// 
-// Copyright (c) 2014, Christian Klauser
-// All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without modification, 
-//  are permitted provided that the following conditions are met:
-// 
-//     Redistributions of source code must retain the above copyright notice, 
-//          this list of conditions and the following disclaimer.
-//     Redistributions in binary form must reproduce the above copyright notice, 
-//          this list of conditions and the following disclaimer in the 
-//          documentation and/or other materials provided with the distribution.
-//     The names of the contributors may be used to endorse or 
-//          promote products derived from this software without specific prior written permission.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
-//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-//  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-//  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
-//  IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+﻿#nullable enable
+
 using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
+using Microsoft.Extensions.ObjectPool;
 using Prexonite;
 using Prexonite.Compiler;
 using Prexonite.Compiler.Build;
+using Prexonite.Compiler.Cil;
 using Prexonite.Modular;
 
 namespace PrexoniteTests.Tests.Configurations;
 
-public static class ModuleCache
+public class ModuleCache
 {
-    [ThreadStatic] 
-    private static IncrementalPlan _plan;
+    public static ModuleCache LeaseFor(bool compileToCil, FunctionLinking functionLinking) => 
+        poolFor(compileToCil, functionLinking).Get();
+    
+    public static void ReturnTo(bool compileToCil, FunctionLinking functionLinking, ModuleCache cache) =>
+        poolFor(compileToCil, functionLinking).Return(cache);
 
-    [ThreadStatic] private static ITargetDescription _legacySymbolsDescription;
+    private static ObjectPool<ModuleCache> poolFor(bool compileToCil, FunctionLinking functionLinking) =>
+        (compileToCil, functionLinking) switch
+        {
+            (false, _) => InterpretedCache,
+            (true, FunctionLinking.FullyIsolated) => IsolatedCilCache,
+            (true, FunctionLinking.FullyStatic) => LinkedCilCache,
+            _ => throw new ArgumentException(
+                $"Test scenario compileToCil={compileToCil}, functionLinking={functionLinking} is not supported.")
+        };
 
-    [ThreadStatic] private static ITargetDescription _stdlibDescription;
+    private static readonly ObjectPool<ModuleCache> InterpretedCache = mkCachePool();
+    private static readonly ObjectPool<ModuleCache> IsolatedCilCache = mkCachePool();
+    private static readonly ObjectPool<ModuleCache> LinkedCilCache = mkCachePool();
 
-    [NotNull] private static readonly TraceSource _trace =
+    private static ObjectPool<ModuleCache> mkCachePool() => 
+        new LeakTrackingObjectPool<ModuleCache>(new DefaultObjectPool<ModuleCache>(
+            new DefaultPooledObjectPolicy<ModuleCache>(), 
+            Environment.ProcessorCount
+            ));
+    
+    private ITargetDescription? _legacySymbolsDescription;
+
+    private ITargetDescription? _stdlibDescription;
+
+    private static readonly TraceSource _trace =
         new("PrexoniteTests.Tests.Configurations.ModuleCache");
 
-// ReSharper disable InconsistentNaming
-    private static ManualPlan Cache
-// ReSharper restore InconsistentNaming
-    {
-        get
-        {
-            LastAccess = DateTime.Now;
-            if (_plan != null) return _plan;
-            else
-            {
-                _trace.TraceEvent(TraceEventType.Information, 0, "Creating empty build plan for thread {0}.", Thread.CurrentThread.ManagedThreadId);
-                return _plan = new IncrementalPlan();
-            }
-        }
-    }
+    // ReSharper disable InconsistentNaming
+    private ManualPlan Cache { get; } = new IncrementalPlan();
 
     // ReSharper disable InconsistentNaming
 
-    private static ITargetDescription _loadLegacySymbols()
+    private ITargetDescription _loadLegacySymbols()
     {
         var moduleName = new ModuleName("prx.v1", new Version(0, 0));
         var desc = Cache.CreateDescription(moduleName,
@@ -85,13 +72,13 @@ public static class ModuleCache
     /// <summary>
     /// Description of the module containing legacy symbols.
     /// </summary>
-    private static ITargetDescription LegacySymbolsDescription =>
+    private ITargetDescription LegacySymbolsDescription =>
         _legacySymbolsDescription ??= _loadLegacySymbols();
     // ReSharper restore InconsistentNaming
 
-    private static ITargetDescription stdlibDescription => _stdlibDescription ??= _loadStdlib();
+    private ITargetDescription stdlibDescription => _stdlibDescription ??= _loadStdlib();
 
-    private static ITargetDescription _loadStdlib()
+    private ITargetDescription _loadStdlib()
     {
         try
         {
@@ -123,28 +110,9 @@ public static class ModuleCache
             _trace.Flush();
         }
     }
-
-    [field: ThreadStatic]
-    public static DateTime LastAccess { get; set; }
-
-    public static bool IsStale => false;
-
-// ReSharper disable InconsistentNaming
-    private static void EnsureFresh()
-// ReSharper restore InconsistentNaming
+    
+    public void Describe(Loader environment, TestDependency script)
     {
-        if (IsStale)
-        {
-            _trace.TraceEvent(TraceEventType.Information, 0, "Delete cached build plan for thread {0}.",
-                Thread.CurrentThread.ManagedThreadId);
-            _plan = null;
-        }
-    }
-        
-    public static void Describe(Loader environment, TestDependency script)
-    {
-        EnsureFresh();
-
         var path = script.ScriptName;
         var dependencies = script.Dependencies ?? Enumerable.Empty<string>();
 
@@ -158,7 +126,7 @@ public static class ModuleCache
         {
             _trace.TraceEvent(TraceEventType.Verbose, 0,
                 "ModuleCache already contains a description of {0} on thread {1}, no action necessary.", moduleName,
-                Thread.CurrentThread.ManagedThreadId);
+                Environment.CurrentManagedThreadId);
             return;
         }
 
@@ -175,12 +143,10 @@ public static class ModuleCache
         Cache.TargetDescriptions.Add(desc);
     }
 
-    public static Tuple<Application,ITarget> Load(string path)
+    public (Application Application, ITarget Target) Load(string path)
     {
-        EnsureFresh();
-
         var targetModuleName = _toModuleName(path);
-        Tuple<Application, ITarget> result;
+        (Application Application, ITarget Target) result;
         try
         {
             result = Cache.Load(targetModuleName);
@@ -198,9 +164,8 @@ public static class ModuleCache
         return new(Path.GetFileNameWithoutExtension(path), new Version(0, 0));
     }
 
-    public static Task<ITarget> BuildAsync(ModuleName name)
+    public Task<ITarget> BuildAsync(ModuleName name)
     {
-        EnsureFresh();
         _trace.TraceEvent(TraceEventType.Information, 0, "Requested asynchronous build of module {0}.", name);
         return Cache.BuildAsync(name, CancellationToken.None);
     }

--- a/PrexoniteTests/Tests/Configurations/ModuleCacheV2.cs
+++ b/PrexoniteTests/Tests/Configurations/ModuleCacheV2.cs
@@ -80,6 +80,6 @@ public static class ModuleCacheV2
             ? (await Compiler.CompileModulesAsync(plan, desc.Name.Singleton(), 
                 sharedEnginePrototype, FunctionLinking.FullyStatic, ct))[desc.Name]
             : await plan.LoadAsync(desc.Name, ct);
-        return loadedAppTask.ToValueTuple();
+        return loadedAppTask;
     }
 }

--- a/PrexoniteTests/Tests/Configurations/UnitTestConfiguration.cs
+++ b/PrexoniteTests/Tests/Configurations/UnitTestConfiguration.cs
@@ -1,30 +1,6 @@
-﻿// Prexonite
-// 
-// Copyright (c) 2014, Christian Klauser
-// All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without modification, 
-//  are permitted provided that the following conditions are met:
-// 
-//     Redistributions of source code must retain the above copyright notice, 
-//          this list of conditions and the following disclaimer.
-//     Redistributions in binary form must reproduce the above copyright notice, 
-//          this list of conditions and the following disclaimer in the 
-//          documentation and/or other materials provided with the distribution.
-//     The names of the contributors may be used to endorse or 
-//          promote products derived from this software without specific prior written permission.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
-//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-//  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-//  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
-//  IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+﻿#nullable enable
+
 using System;
-using System.IO;
 using System.Linq;
 using NUnit.Framework;
 using Prexonite;
@@ -33,42 +9,10 @@ using Prexonite.Compiler.Cil;
 
 namespace PrexoniteTests.Tests.Configurations;
 
-internal abstract class UnitTestConfiguration
+internal abstract class UnitTestConfiguration : IDisposable
 {
     public class InMemory : UnitTestConfiguration
     {
-    }
-
-    public class FromStored : UnitTestConfiguration
-    {
-        public FromStored()
-        {
-            throw new NotSupportedException("Store round-tripping is not currently implemented.");
-        }
-
-        internal override void Configure(TestModel model, ScriptedUnitTestContainer container)
-        {
-            // Rewire the units under test to point to stored representations
-            var originalUnits = model.UnitsUnderTest.ToList();
-            var storedNameMap = originalUnits.ToDictionary(td => td.ScriptName,
-                td =>
-                {
-                    var ext = Path.GetExtension(td.ScriptName);
-                    var extLen = ext?.Length ?? 0;
-                    var baseName = td.ScriptName.Substring(td.ScriptName.Length - extLen);
-                    return $"{baseName}~-stored{ext}";
-                });
-
-            model.UnitsUnderTest = model.UnitsUnderTest.Select(td => new TestDependency
-            {
-                ScriptName = storedNameMap[td.ScriptName],
-                Dependencies = td.Dependencies.Select(d => storedNameMap[d]).ToArray()
-            }).ToArray();
-
-            // Configure the test as per usual
-            base.Configure(model, container);
-        }
-
     }
 
     protected UnitTestConfiguration()
@@ -77,8 +21,23 @@ internal abstract class UnitTestConfiguration
         CompileToCil = false;
     }
 
-    public FunctionLinking Linking { get; set; }
-    public bool CompileToCil { get; set; }
+    public FunctionLinking Linking { get; init; }
+    public bool CompileToCil { get; init; }
+
+    private bool _configured;
+    private ModuleCache? _cache;
+
+    public ModuleCache Cache
+    {
+        get
+        {
+            if (!_configured)
+            {
+                throw new InvalidOperationException("Must call Configure before accessing the module cache.");
+            }
+            return _cache ??= ModuleCache.LeaseFor(CompileToCil, Linking);
+        }
+    }
 
     /// <summary>
     /// Executed as the last step of loading, immediately before the actual test methods are executed.
@@ -90,28 +49,31 @@ internal abstract class UnitTestConfiguration
             Compiler.Compile(runner.Application, runner.Engine, Linking);
     }
 
-    protected static void LoadUnitTestingFramework(ScriptedUnitTestContainer container)
+    protected void LoadUnitTestingFramework(ScriptedUnitTestContainer container)
     {
-        ModuleCache.Describe(container.Loader,new TestDependency
+        Cache.Describe(container.Loader,new TestDependency
         {
             ScriptName = ScriptedUnitTestContainer.PrexoniteUnitTestFramework
         });
     }
 
 // ReSharper disable InconsistentNaming
-    internal virtual void Configure(TestModel model, ScriptedUnitTestContainer container)
+    internal void Configure(TestModel model, ScriptedUnitTestContainer container)
 // ReSharper restore InconsistentNaming
     {
+        // We can be certain that CompileToCil and Linking are set
+        _configured = true;
+
         // describe units under test
         foreach (var unit in model.UnitsUnderTest)
-            ModuleCache.Describe(container.Loader, unit);
+            Cache.Describe(container.Loader, unit);
 
         // describe unit testing framework
         LoadUnitTestingFramework(container);
 
         // describe unit testing extensions
         foreach(var extension in model.TestDependencies)
-            ModuleCache.Describe(container.Loader, extension);
+            Cache.Describe(container.Loader, extension); 
 
         // describe test suite
         var suiteDependencies =
@@ -124,10 +86,10 @@ internal abstract class UnitTestConfiguration
         {
             ScriptName = model.TestSuiteScript, Dependencies = suiteDependencies
         };
-        ModuleCache.Describe(container.Loader, suiteDescription);
+        Cache.Describe(container.Loader, suiteDescription);
 
         // Finally instantiate the test suite application(s)
-        var (application, target) = ModuleCache.Load(model.TestSuiteScript);
+        var (application, target) = Cache.Load(model.TestSuiteScript);
         container.Application = application;
         container.PrintCompound();
 
@@ -150,5 +112,15 @@ internal abstract class UnitTestConfiguration
         }
 
         _prepareExecution(container);
+    }
+
+    public void Dispose()
+    {
+        if(!_configured)    
+            return;
+        if (_cache is { } cache)
+        {
+            ModuleCache.ReturnTo(CompileToCil, Linking, cache);
+        }
     }
 }

--- a/PrexoniteTests/Tests/Configurations/VMTestConfigurations.tt
+++ b/PrexoniteTests/Tests/Configurations/VMTestConfigurations.tt
@@ -50,36 +50,6 @@ namespace PrexoniteTests.Tests.Configurations
         protected override UnitTestConfiguration Runner => _runner;
     }
 
-    [TestFixture]
-    [Explicit]
-    [GeneratedCode("VMTestConfiguration.tt","0.0")]
-    internal class <#=baseName#>_StoredInterpreted : <#=className#>
-    {
-        private readonly UnitTestConfiguration _runner = new UnitTestConfiguration.FromStored();
-        protected override UnitTestConfiguration Runner => _runner;
-    }
-
-    [TestFixture]
-    [Explicit]
-    [GeneratedCode("VMTestConfiguration.tt","0.0")]
-    internal class <#=baseName#>_StoredCilStatic : <#=className#>
-    {
-        private readonly UnitTestConfiguration _runner = new UnitTestConfiguration.FromStored{CompileToCil=true};
-        protected override UnitTestConfiguration Runner => _runner;
-    }
-
-    
-    [TestFixture]
-    [Explicit]
-    [GeneratedCode("VMTestConfiguration.tt","0.0")]
-    internal class <#=baseName#>_StoredCilIsolated : <#=className#>
-    {
-        private readonly UnitTestConfiguration _runner = new UnitTestConfiguration.FromStored{
-            CompileToCil=true,
-            Linking = FunctionLinking.JustAvailableForLinking
-        };
-        protected override UnitTestConfiguration Runner => _runner;
-    }
 <# } #>
 
 <# foreach(var testFile in _getTestConfigurationV2()) {

--- a/Prx/Program.cs
+++ b/Prx/Program.cs
@@ -283,12 +283,12 @@ internal static class Program
             
         #region Self-assembling build plan reference
 
-        engine.Commands.AddHostCommand(@"host\self_assembling_build_plan", (sctx, args) => sctx.CreateNativePValue(plan));
+        engine.Commands.AddHostCommand(@"host\self_assembling_build_plan", (sctx, _) => sctx.CreateNativePValue(plan));
         engine.Commands.AddHostCommand(@"host\prx_path", (sctx, args) => sctx.CreateNativePValue(prxPath));
 
         #endregion
 
-        Tuple<Application, ITarget> result;
+        (Application Application, ITarget Target)? result;
         try
         {
             var entryDesc = plan.AssembleAsync(Source.FromEmbeddedResource(Assembly.GetAssembly(typeof(Program))!, PrxScriptFileName)).Result;
@@ -331,10 +331,10 @@ internal static class Program
             return null;
         }
 
-        if (_reportErrors(result.Item2.Messages)) 
+        if (_reportErrors(result.Value.Target.Messages)) 
             return null;
             
-        var app = result.Item1;
+        var app = result.Value.Application;
         app.Meta["Version"] = Assembly.GetExecutingAssembly().GetName()!.Version!.ToString();
         return app;
 

--- a/Prx/psr/debug/debug.pxs
+++ b/Prx/psr/debug/debug.pxs
@@ -616,11 +616,7 @@ function as ensure_compiled_to_cil(f) [is debug\reqcil;]
     {
         if(not f.HasCilImplementation)
         {
-            call(CompileToCil(?), 
-                asm(ldr.app).Functions 
-                >> where(f => f.Meta[@"debug\reqcil"].Switch) 
-                >> all
-            );
+            CompileToCil;
         }
     }
     else if(f is ::Closure)

--- a/Prx/src/prx_interactive.pxs
+++ b/Prx/src/prx_interactive.pxs
@@ -1,8 +1,3 @@
-build
-{
-    require("resource:Prx:prx_lib.pxs");
-}
-
 Import { System, System::Text, Prexonite, Prexonite::Compiler };
 
 namespace prx.cli

--- a/Prx/src/prx_main.pxs
+++ b/Prx/src/prx_main.pxs
@@ -2,9 +2,9 @@ Name prx::cli;
 Description "prx command line interface (compiler and REPL)";
 Author "Christian Klauser";
 
-build does require(
-    "resource:Prx:prx_interactive.pxs", 
-    "resource:Prx:prx_lib.pxs"
+build does require( 
+    "resource:Prx:prx_lib.pxs",
+    "resource:Prx:prx_interactive.pxs"
 );
 
 namespace prx.cli


### PR DESCRIPTION
Breaking: remove PCommand.IsPure, PCommand.Groups, PCommand.IsInGroup, PCommand.AddToGroup, PCommand.RemoveFromGroup (groups are now tracked in the command table)

Breaking: `sys.rt.compile_to_cil` will now compile the entire compound (not just the current application)

Fix bug in stack context passing across module boundaries.

Fix broken prx scripts

Remove stored tests (round-trip). They have been disabled for a while and there are no plans to bring back support for round-tripping.